### PR TITLE
Avoid focus on floating signature help

### DIFF
--- a/lua/nvchad_ui/signature.lua
+++ b/lua/nvchad_ui/signature.lua
@@ -12,8 +12,6 @@ M.signature_window = function(_, result, ctx, config)
             relative = "cursor",
             row = 0,
             col = -1,
-            border = "single",
-            focusable = false,
          })
       end
    end
@@ -69,7 +67,10 @@ local open_signature = function()
 
    if triggered then
       local params = util.make_position_params()
-      vim.lsp.buf_request(0, "textDocument/signatureHelp", params, vim.lsp.with(M.signature_window, {}))
+      vim.lsp.buf_request(0, "textDocument/signatureHelp", params, vim.lsp.with(M.signature_window, {
+          border = "single",
+          focusable = false,
+      }))
    end
 end
 


### PR DESCRIPTION
Signature help seem to ignore the focussable option when the signature is shown
for an "space" character, if the prev char couldn't show the signature. For
example (python example):
 getattr(foo, )
              ^ here if we type fast enough for the first signature to be shown
we get a focus on the opening parens of the signature help window. Annoyingly
enough, the only way to get rid of the window is using the mouse to change the
focus once again.