### PR TITLE
feat: allow recursive folder search

### DIFF
--- a/lua/nvchad_ui/tabufline/modules.lua
+++ b/lua/nvchad_ui/tabufline/modules.lua
@@ -90,8 +90,31 @@ local function add_fileInfo(name, bufnr)
     -- check for same buffer names under different dirs
     for _, value in ipairs(vim.t.bufs) do
       if api.nvim_buf_is_valid(value) then
+
         if name == fn.fnamemodify(api.nvim_buf_get_name(value), ":t") and value ~= bufnr then
-          name = api.nvim_buf_get_name(bufnr):match "[^/]*/?[^/]*$"
+          local other = {};
+          for match in (api.nvim_buf_get_name(value).."/"):gmatch("(.-)".."/") do
+            table.insert(other, match);
+          end
+
+          local current = {};
+          for match in (api.nvim_buf_get_name(bufnr).."/"):gmatch("(.-)".."/") do
+            table.insert(current, match);
+          end
+
+          name = current[#current]
+
+          for i = #current - 1, 1, -1 do
+
+            local value_current = current[i]
+            local other_current = other[i]
+
+            if value_current ~= other_current then
+              name = value_current .. "/../" .. name
+              break
+            end
+
+          end
           break
         end
       end


### PR DESCRIPTION
This PR aims to display the first different folder instead of the first one.

My use case is that I have:

```
- net/src/lib.rs
- node/src/lib.rs
```

which end up being both `src/lib.rs` in the tabufline.
This PR is a draft because I'm not really use to code in lua so please, feel free to suggest code changes !

The current state is:

![Screenshot 2022-08-11 at 15 56 12](https://user-images.githubusercontent.com/1394604/184150583-d2fce6e4-ccd8-445f-9a77-52dd68c77e46.png)


Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>