### PR TITLE
fix(tabuflist): some buf is not legible when nvim-tree is on the right

### DIFF
--- a/lua/nvchad_ui/tabufline/modules.lua
+++ b/lua/nvchad_ui/tabufline/modules.lua
@@ -138,7 +138,7 @@ end
 local M = {}
 
 M.CoverNvimTree = function()
-  return "%#NvimTreeNormal#" .. string.rep(" ", getNvimTreeWidth())
+  return "%#NvimTreeNormal#" .. (vim.g.nvimtree_side == "right" and "" or string.rep(" ", getNvimTreeWidth()))
 end
 
 M.bufferlist = function()


### PR DESCRIPTION
fix #6