### PR TITLE
Fix(tabufline): fixed incorrect buf validity check, fixed adding current buf to new tab 

### DIFF
--- a/lua/nvchad_ui/tabufline/init.lua
+++ b/lua/nvchad_ui/tabufline/init.lua
@@ -1,7 +1,10 @@
 local M = {}
 local api = vim.api
 
-local utils = require "nvchad_ui.tabufline.utils"
+M.isBufValid = function(bufnr)
+  return vim.api.nvim_buf_is_valid(bufnr) and vim.bo[bufnr].buflisted
+end
+
 M.bufilter = function()
   local bufs = vim.t.bufs or nil
 
@@ -10,7 +13,7 @@ M.bufilter = function()
   end
 
   for i = #bufs, 1, -1 do
-    if not utils.isBufValid(bufs[i]) then
+    if not M.isBufValid(bufs[i]) then
       table.remove(bufs, i)
     end
   end

--- a/lua/nvchad_ui/tabufline/init.lua
+++ b/lua/nvchad_ui/tabufline/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 local api = vim.api
 
+local utils = require "nvchad_ui.tabufline.utils"
 M.bufilter = function()
   local bufs = vim.t.bufs or nil
 
@@ -9,7 +10,7 @@ M.bufilter = function()
   end
 
   for i = #bufs, 1, -1 do
-    if not api.nvim_buf_is_valid(bufs[i]) then
+    if not utils.isBufValid(bufs[i]) then
       table.remove(bufs, i)
     end
   end

--- a/lua/nvchad_ui/tabufline/lazyload.lua
+++ b/lua/nvchad_ui/tabufline/lazyload.lua
@@ -19,7 +19,7 @@ return function(opts)
         if
           not vim.tbl_contains(bufs, args.buf)
           and (args.event == "BufEnter" or vim.bo[args.buf].buflisted)
-          and args.event ~= "BufAdd"
+          and args.buf ~= vim.api.nvim_get_current_buf()
         then
           table.insert(bufs, args.buf)
           vim.t.bufs = bufs

--- a/lua/nvchad_ui/tabufline/lazyload.lua
+++ b/lua/nvchad_ui/tabufline/lazyload.lua
@@ -11,12 +11,16 @@ return function(opts)
   vim.api.nvim_create_autocmd({ "BufAdd", "BufEnter", "tabnew" }, {
     callback = function(args)
       if vim.t.bufs == nil then
-        vim.t.bufs = { args.buf }
+        vim.t.bufs = vim.api.nvim_get_current_buf() == args.buf and {} or { args.buf }
       else
         local bufs = vim.t.bufs
 
         -- check for duplicates
-        if not vim.tbl_contains(bufs, args.buf) and (args.event == "BufAdd" or vim.bo[args.buf].buflisted) then
+        if
+          not vim.tbl_contains(bufs, args.buf)
+          and (args.event == "BufEnter" or vim.bo[args.buf].buflisted)
+          and args.event ~= "BufAdd"
+        then
           table.insert(bufs, args.buf)
           vim.t.bufs = bufs
         end

--- a/lua/nvchad_ui/tabufline/lazyload.lua
+++ b/lua/nvchad_ui/tabufline/lazyload.lua
@@ -19,7 +19,8 @@ return function(opts)
         if
           not vim.tbl_contains(bufs, args.buf)
           and (args.event == "BufEnter" or vim.bo[args.buf].buflisted)
-          and args.buf ~= vim.api.nvim_get_current_buf()
+          and (args.event == "BufEnter" or args.buf ~= vim.api.nvim_get_current_buf())
+          and args.event ~= "BufAdd"
         then
           table.insert(bufs, args.buf)
           vim.t.bufs = bufs

--- a/lua/nvchad_ui/tabufline/modules.lua
+++ b/lua/nvchad_ui/tabufline/modules.lua
@@ -2,7 +2,7 @@ local api = vim.api
 local devicons_present, devicons = pcall(require, "nvim-web-devicons")
 local fn = vim.fn
 local new_cmd = api.nvim_create_user_command
-local utils = require "nvchad_ui.tabufline.utils"
+local isBufValid = require("nvchad_ui.tabufline").isBufValid
 
 require("base46").load_highlight "tbline"
 
@@ -98,7 +98,7 @@ local function add_fileInfo(name, bufnr)
 
     -- check for same buffer names under different dirs
     for _, value in ipairs(vim.t.bufs) do
-      if utils.isBufValid(value) then
+      if isBufValid(value) then
         if name == fn.fnamemodify(api.nvim_buf_get_name(value), ":t") and value ~= bufnr then
           local other = {}
           for match in (api.nvim_buf_get_name(value) .. "/"):gmatch("(.-)" .. "/") do
@@ -176,7 +176,7 @@ M.bufferlist = function()
 
   vim.g.bufirst = 0
   for _, bufnr in ipairs(vim.t.bufs) do
-    if utils.isBufValid(bufnr) then
+    if isBufValid(bufnr) then
       if ((#buffers + 1) * 21) > available_space then
         if has_current then
           break

--- a/lua/nvchad_ui/tabufline/modules.lua
+++ b/lua/nvchad_ui/tabufline/modules.lua
@@ -2,6 +2,7 @@ local api = vim.api
 local devicons_present, devicons = pcall(require, "nvim-web-devicons")
 local fn = vim.fn
 local new_cmd = api.nvim_create_user_command
+local utils = require "nvchad_ui.tabufline.utils"
 
 require("base46").load_highlight "tbline"
 
@@ -97,7 +98,7 @@ local function add_fileInfo(name, bufnr)
 
     -- check for same buffer names under different dirs
     for _, value in ipairs(vim.t.bufs) do
-      if api.nvim_buf_is_valid(value) then
+      if utils.isBufValid(value) then
         if name == fn.fnamemodify(api.nvim_buf_get_name(value), ":t") and value ~= bufnr then
           local other = {}
           for match in (api.nvim_buf_get_name(value) .. "/"):gmatch("(.-)" .. "/") do
@@ -175,7 +176,7 @@ M.bufferlist = function()
 
   vim.g.bufirst = 0
   for _, bufnr in ipairs(vim.t.bufs) do
-    if api.nvim_buf_is_valid(bufnr) then
+    if utils.isBufValid(bufnr) then
       if ((#buffers + 1) * 21) > available_space then
         if has_current then
           break

--- a/lua/nvchad_ui/tabufline/utils.lua
+++ b/lua/nvchad_ui/tabufline/utils.lua
@@ -1,5 +1,0 @@
-local M = {}
-M.isBufValid = function(bufnr)
-  return vim.api.nvim_buf_is_valid(bufnr) and vim.bo[bufnr].buflisted
-end
-return M

--- a/lua/nvchad_ui/tabufline/utils.lua
+++ b/lua/nvchad_ui/tabufline/utils.lua
@@ -1,0 +1,5 @@
+local M = {}
+M.isBufValid = function(bufnr)
+  return vim.api.nvim_buf_is_valid(bufnr) and vim.bo[bufnr].buflisted
+end
+return M


### PR DESCRIPTION
Combine `vim.api.nvim_buf_is_valid` with `vim.bo[bufnr].buflisted` to verify `buffer`.
Fix #22