### PR TITLE
Fix(tabufline): Removing wrong bufs.

### DIFF
--- a/lua/nvchad_ui/tabufline/lazyload.lua
+++ b/lua/nvchad_ui/tabufline/lazyload.lua
@@ -21,7 +21,6 @@ return function(opts)
           not vim.tbl_contains(bufs, args.buf)
           and (args.event == "BufEnter" or vim.bo[args.buf].buflisted)
           and (args.event == "BufEnter" or args.buf ~= vim.api.nvim_get_current_buf())
-          and args.event ~= "BufAdd"
           and isBufValid(args.buf)
         then
           table.insert(bufs, args.buf)


### PR DESCRIPTION
The bug introduced by #30 described by #37 , except for the bug described by #37 , there is a bug that the `:terminal` does not display before fixing. Repair now, please review. @siduck @charludo @jtuz