### PR TITLE
Make kt icon display properly

### DIFF
--- a/lua/nvchad_ui/icons.lua
+++ b/lua/nvchad_ui/icons.lua
@@ -110,7 +110,7 @@ M.devicons = {
   },
 
   kt = {
-    icon = "󱈙",
+    icon = "",
     name = "kt",
   },
 


### PR DESCRIPTION
The kotlin icon does not display correctly.

```lua
M.devicons = function()
  local present, devicons = pcall(require, "nvim-web-devicons")

  if present then
    require("base46").load_highlight "devicons"

    local options = { override = require("nvchad_ui.icons").devicons }
```
![Screenshot 2022-12-26 at 18 44 21](https://user-images.githubusercontent.com/3609616/209572632-cc6d26c4-8583-4318-b550-e43372156639.png)
When I replaced this last line with
```lua
    local options = { override = {} }
```
It was displayed properly (`kts` already works because there's no override in this repo)


![Screenshot 2022-12-26 at 18 44 38](https://user-images.githubusercontent.com/3609616/209572624-9b38dcbd-77d9-47bd-ab32-9e814cdf78c7.png)

So I assume there's something wrong with the icon in this repo. I copied it from https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons.lua#L756. Or maybe the override could be removed?

