### PR TITLE
Minor fixes when icon/group is empty, and tab parsing

### DIFF
--- a/lua/nvchad_ui/tabufline/lazyload.lua
+++ b/lua/nvchad_ui/tabufline/lazyload.lua
@@ -56,13 +56,13 @@ return function(opts)
       callback = function()
         if #vim.fn.getbufinfo { buflisted = 1 } >= 2 or #vim.api.nvim_list_tabpages() >= 2 then
           vim.opt.showtabline = 2
-          vim.opt.tabline = "%!v:lua.require('nvchad_ui').tabufline()"
+          vim.opt.tabline = "%!v:lua.require'nvchad_ui'.tabufline()"
           vim.api.nvim_del_augroup_by_name "TabuflineLazyLoad"
         end
       end,
     })
   else
     vim.opt.showtabline = 2
-    vim.opt.tabline = "%!v:lua.require('nvchad_ui').tabufline()"
+    vim.opt.tabline = "%!v:lua.require'nvchad_ui'.tabufline()"
   end
 end

--- a/lua/nvchad_ui/tabufline/modules.lua
+++ b/lua/nvchad_ui/tabufline/modules.lua
@@ -58,8 +58,9 @@ end, {})
 local function new_hl(group1, group2)
   local fg = fn.synIDattr(fn.synIDtrans(fn.hlID(group1)), "fg#")
   local bg = fn.synIDattr(fn.synIDtrans(fn.hlID(group2)), "bg#")
-  api.nvim_set_hl(0, "Tbline" .. group1 .. group2, { fg = fg, bg = bg })
-  return "%#" .. "Tbline" .. group1 .. group2 .. "#"
+  local cgroup = (group1 and group1 or "") .. (group2 and group2 or "")
+  api.nvim_set_hl(0, "Tbline" .. cgroup, { fg = fg, bg = bg })
+  return "%#" .. "Tbline" .. cgroup .. "#"
 end
 
 local function getNvimTreeWidth()
@@ -92,8 +93,8 @@ local function add_fileInfo(name, bufnr)
     local padding = (24 - #name - 5) / 2
 
     icon = (
-      api.nvim_get_current_buf() == bufnr and new_hl(icon_hl, "TbLineBufOn") .. " " .. icon
-      or new_hl(icon_hl, "TbLineBufOff") .. " " .. icon
+      api.nvim_get_current_buf() == bufnr and new_hl(icon_hl, "TbLineBufOn") .. " " .. (icon and icon or "")
+      or new_hl(icon_hl, "TbLineBufOff") .. " " .. (icon and icon or "")
     )
 
     -- check for same buffer names under different dirs


### PR DESCRIPTION
1. Sometimes, the tabline is considered invalid (E15: Invalid expression). Using require'nvchad_ui' instead of require('nvchad_ui') fixes the issue. 

- https://github.com/reflog/NvChad/commit/26874c5d605a3888f5d5862272ae3d88a0fcac48
- https://github.com/NvChad/NvChad/issues/1265

2. When I am using nvim-ide plugin, the group or icon can be nil and cause errors. Need to handle this special case. 