### PR TITLE
[STATUSLINE] Add module to show spell-check language

### DIFF
--- a/lua/nvchad_ui/statusline/init.lua
+++ b/lua/nvchad_ui/statusline/init.lua
@@ -10,6 +10,7 @@ return {
 
     return table.concat {
       modules.mode(),
+      modules.spell(),
       modules.fileInfo(),
       modules.git(),
 

--- a/lua/nvchad_ui/statusline/modules.lua
+++ b/lua/nvchad_ui/statusline/modules.lua
@@ -147,4 +147,16 @@ M.cursor_position = function()
   return left_sep .. "%#St_pos_text#" .. " " .. text .. " "
 end
 
+M.spell = function()
+  local spell = vim.api.nvim_get_option_value("spell", {})
+  local spelllang = vim.api.nvim_get_option_value("spelllang", {})
+
+  if not spell then
+    return ""
+  end
+
+  return "%#St_file_info#" .. "Spell: " .. spelllang .. " " .. "%#St_file_sep#" .. sep_r
+
+end
+
 return M


### PR DESCRIPTION
I use native vim spell-check feature as it helps me find typos in regular text. Usually statusline plugins show if spell-check is on by indicating which spell-check language is set as. I tried adding the same to `statusline` using simple function, but I need some guidance getting it in shape as with the rest of the `statusline`, as currently it shows as:
<img width="1427" alt="Screenshot of NvChad statusline after with spell-check module added to it" src="https://user-images.githubusercontent.com/316734/212557809-e39aea95-4900-4d4b-ab17-fdf8feca8abe.png">
