### PR TITLE
Signature: Make automatic signature help configurable

### DIFF
--- a/lua/nvchad_ui/signature.lua
+++ b/lua/nvchad_ui/signature.lua
@@ -1,4 +1,5 @@
-local config = require("core.utils").load_config().ui.signature or {}
+local config = require("core.utils").load_config().ui.lsp.signature 
+
 -- thx to https://gitlab.com/ranjithshegde/dotbare/-/blob/master/.config/nvim/lua/lsp/init.lua
 local M = {}
 

--- a/lua/nvchad_ui/signature.lua
+++ b/lua/nvchad_ui/signature.lua
@@ -1,3 +1,4 @@
+local config = require("core.utils").load_config().ui.signature or {}
 -- thx to https://gitlab.com/ranjithshegde/dotbare/-/blob/master/.config/nvim/lua/lsp/init.lua
 local M = {}
 
@@ -74,12 +75,16 @@ local open_signature = function()
       vim.lsp.with(M.signature_window, {
         border = "single",
         focusable = false,
+        silent = config.silent,
       })
     )
   end
 end
 
 M.setup = function(client)
+  if config.disabled then
+    return
+  end
   table.insert(clients, client)
   local group = augroup("LspSignature", { clear = false })
   vim.api.nvim_clear_autocmds { group = group, pattern = "<buffer>" }


### PR DESCRIPTION
Adds config options to `ui.signature`:

```lua
ui = {
  ...
  signature = {
    disabled = false, -- set to true to completely disable automatic signature help
    silent = false, -- set to true to stop the 'no signature help available' message from appearing
}
```

Resolves #54 