### PR TITLE
fix(modules): fix path dissection for windows

### DIFF
--- a/lua/nvchad_ui/tabufline/modules.lua
+++ b/lua/nvchad_ui/tabufline/modules.lua
@@ -69,12 +69,12 @@ local function add_fileInfo(name, bufnr)
       if isBufValid(value) then
         if name == fn.fnamemodify(api.nvim_buf_get_name(value), ":t") and value ~= bufnr then
           local other = {}
-          for match in (api.nvim_buf_get_name(value) .. "/"):gmatch("(.-)" .. "/") do
+          for match in (vim.fs.normalize(api.nvim_buf_get_name(value)) .. "/"):gmatch("(.-)" .. "/") do
             table.insert(other, match)
           end
 
           local current = {}
-          for match in (api.nvim_buf_get_name(bufnr) .. "/"):gmatch("(.-)" .. "/") do
+          for match in (vim.fs.normalize(api.nvim_buf_get_name(bufnr)) .. "/"):gmatch("(.-)" .. "/") do
             table.insert(current, match)
           end
 
@@ -85,7 +85,11 @@ local function add_fileInfo(name, bufnr)
             local other_current = other[i]
 
             if value_current ~= other_current then
-              name = value_current .. "/../" .. name
+              if (#current - i) < 2 then
+                name = value_current .. "/" .. name
+              else
+                name = value_current .. "/../" .. name
+              end
               break
             end
           end


### PR DESCRIPTION
Hi guys, I have added a fix where for windows path the breakdown of paths to find similar path was not happening due to windows using "\\" instead of "/" like unix path. 

So before behavior
<img width="707" alt="bug" src="https://user-images.githubusercontent.com/31726036/227713404-d257b76e-31f4-4a5f-b716-b10e68cd3d6d.png">

After fix
<img width="1220" alt="fix" src="https://user-images.githubusercontent.com/31726036/227713412-37d353ff-064e-4747-a733-1aec60e0d3c7.png">

Ihave also encountered cases where the nvim api also sometimes gives path seperator of both types like "dev\neovim\nvchad-ui/lua/nvchad-ui" so I have converted all windows type path to unix path to handle those cases as well.

I have also changed the path display to display single "/" in tab instead of "/../" if the directory is parent itself. I hope this is okay as I thought it may be confusing.