### PR TITLE
Equalize length of the cursor_position block in default style

### DIFF
--- a/lua/nvchad_ui/statusline/default.lua
+++ b/lua/nvchad_ui/statusline/default.lua
@@ -154,6 +154,7 @@ M.cursor_position = function()
   local current_line = fn.line "."
   local total_line = fn.line "$"
   local text = math.modf((current_line / total_line) * 100) .. tostring "%%"
+  text = string.format("%4s", text)
 
   text = (current_line == 1 and "Top") or text
   text = (current_line == total_line and "Bot") or text


### PR DESCRIPTION
When cursor changes its position from 0th line to the 1st, this block transforms from "Top" to "0%", which has one characrer less. The whole right block is twitching because of this.