### PR TITLE
fix(nvdash): fix resize and cursor movement

### DIFF
--- a/lua/nvchad_ui/nvdash/init.lua
+++ b/lua/nvchad_ui/nvdash/init.lua
@@ -33,10 +33,6 @@ M.open = function(buf)
     buf = buf or api.nvim_create_buf(false, true)
     api.nvim_win_set_buf(api.nvim_get_current_win(), buf)
 
-    if get_win_height(0) < max_height then
-      return
-    end
-
     vim.opt_local.filetype = "nvdash"
 
     -- close windows i.e splits
@@ -78,12 +74,12 @@ M.open = function(buf)
     local result = {}
 
     -- make all lines available
-    for i = 1, get_win_height(0) do
+    for i = 1, math.max(get_win_height(0), max_height) do
       result[i] = ""
     end
 
-    local headerStart_Index = math.floor((get_win_height(0) / 2) - (#dashboard / 2))
-    local abc = math.floor((get_win_height(0) / 2) - (#dashboard / 2))
+    local headerStart_Index = math.abs(math.floor((get_win_height(0) / 2) - (#dashboard / 2))) + 1 -- 1 = To handle zero case
+    local abc = math.abs(math.floor((get_win_height(0) / 2) - (#dashboard / 2))) + 1 -- 1 = To handle zero case
 
     -- set ascii
     for _, val in ipairs(dashboard) do
@@ -115,7 +111,11 @@ M.open = function(buf)
     end
 
     vim.keymap.set("n", "h", "", { buffer = true })
+    vim.keymap.set("n", "<Left>", "", { buffer = true })
     vim.keymap.set("n", "l", "", { buffer = true })
+    vim.keymap.set("n", "<Right>", "", { buffer = true })
+    vim.keymap.set("n", "<Up>", "", { buffer = true })
+    vim.keymap.set("n", "<Down>", "", { buffer = true })
 
     vim.keymap.set("n", "k", function()
       local cur = fn.line "."


### PR DESCRIPTION
Fixed Resize of nvdash which before failed and even after resize was not able to run the dashboard.
Also fixed the cursor to move only along buttons of dashboard.


Before Resize:

![before_resize](https://user-images.githubusercontent.com/31726036/228509401-3520bab3-795d-4636-90b7-946dfac16692.gif)

After Resize:

![after_resize](https://user-images.githubusercontent.com/31726036/228509506-80ca13ed-8b11-42b2-a83b-d6f43709c607.gif)

Before cursor movement

![before_move](https://user-images.githubusercontent.com/31726036/228509619-80ad7a87-4d15-474c-ae52-4f34589e7d3e.gif)

After cursor movement

![after_move](https://user-images.githubusercontent.com/31726036/228509700-0b010226-d2b9-4222-b75e-b899378d41ca.gif)
