### PR TITLE
fix(statusline): fix cursor_position return statement

### DIFF
--- a/lua/nvchad_ui/statusline/minimal.lua
+++ b/lua/nvchad_ui/statusline/minimal.lua
@@ -158,7 +158,7 @@ end
 
 
 M.cursor_position = function()
-    gen_block("", "%l/%c", "%#St_Pos_sep#", "%#St_Pos_bg#", "%#St_Pos_txt#")
+  return gen_block("", "%l/%c", "%#St_Pos_sep#", "%#St_Pos_bg#", "%#St_Pos_txt#")
 end
 
 M.run = function()


### PR DESCRIPTION
Fixed cursor_position function of minimal statusline file which doesn't contain a return statement causing it to display nothing.