### PR TITLE
fix: checking table contains with nil table

### DIFF
--- a/lua/nvchad_ui/tabufline/lazyload.lua
+++ b/lua/nvchad_ui/tabufline/lazyload.lua
@@ -18,6 +18,9 @@ vim.t.bufs = listed_bufs
 vim.api.nvim_create_autocmd({ "BufAdd", "BufEnter", "tabnew" }, {
   callback = function(args)
     local bufs = vim.t.bufs
+    if not bufs then
+      bufs = {}
+    end
 
     -- check for duplicates
     if

--- a/lua/nvchad_ui/tabufline/modules.lua
+++ b/lua/nvchad_ui/tabufline/modules.lua
@@ -147,24 +147,27 @@ end
 
 M.bufferlist = function()
   local buffers = {} -- buffersults
+  local current_buffers = vim.t.bufs
   local available_space = vim.o.columns - getNvimTreeWidth() - getBtnsWidth()
   local current_buf = api.nvim_get_current_buf()
   local has_current = false -- have we seen current buffer yet?
 
   vim.g.bufirst = 0
-  for _, bufnr in ipairs(vim.t.bufs) do
-    if isBufValid(bufnr) then
-      if ((#buffers + 1) * 21) > available_space then
-        if has_current then
-          break
+  if current_buffers then
+    for _, bufnr in ipairs(current_buffers) do
+      if isBufValid(bufnr) then
+        if ((#buffers + 1) * 21) > available_space then
+          if has_current then
+            break
+          end
+
+          vim.g.bufirst = vim.g.bufirst + 1
+          table.remove(buffers, 1)
         end
 
-        vim.g.bufirst = vim.g.bufirst + 1
-        table.remove(buffers, 1)
+        has_current = (bufnr == current_buf and true) or has_current
+        table.insert(buffers, styleBufferTab(bufnr))
       end
-
-      has_current = (bufnr == current_buf and true) or has_current
-      table.insert(buffers, styleBufferTab(bufnr))
     end
   end
 


### PR DESCRIPTION
When running `:checkhealth` without any buffers open, I noticed an error, which was attributed to the `bufs` variable being `nil`.
I believe this should fix the issue.

It additionally also fixes another occasion where we were calling `ipairs` on a `nil` value of the `vim.t.bufs`