### PR TITLE
Improve cheatsheet UX

### DIFF
--- a/lua/nvchad_ui/init.lua
+++ b/lua/nvchad_ui/init.lua
@@ -26,7 +26,7 @@ end
 -- command to toggle cheatsheet
 new_cmd("NvCheatsheet", function()
   if vim.g.nvcheatsheet_displayed then
-    vim.cmd "bd"
+    require("nvchad_ui.tabufline").close_buffer()
   else
     require("nvchad_ui.cheatsheet." .. config.cheatsheet.theme)()
   end

--- a/lua/nvchad_ui/tabufline/init.lua
+++ b/lua/nvchad_ui/tabufline/init.lua
@@ -69,6 +69,10 @@ M.close_buffer = function(bufnr)
 
     -- handle unlisted
     elseif not vim.bo.buflisted then
+      if not vim.t.bufs[1] then
+        vim.cmd "enew"
+        return
+      end
       vim.cmd("b" .. vim.t.bufs[1] .. " | bw" .. bufnr)
       return
     else


### PR DESCRIPTION
Currently It's not really convenient to close the buffer. It could create a mess if you have opened additional windows (for example using "dapui" or "nvim-tree")