### PR TITLE
resolve nvim deprecation of get_progress_messages()

### DIFF
--- a/lua/nvchad_ui/statusline/default.lua
+++ b/lua/nvchad_ui/statusline/default.lua
@@ -107,7 +107,12 @@ M.LSP_progress = function()
     return ""
   end
 
-  local Lsp = vim.lsp.util.get_progress_messages()[1]
+  local Lsp
+  if vim.lsp.status then
+    Lsp = vim.lsp.status()
+  else
+    Lsp = vim.lsp.util.get_progress_messages()[1]
+  end
 
   if vim.o.columns < 120 or not Lsp then
     return ""

--- a/lua/nvchad_ui/statusline/default.lua
+++ b/lua/nvchad_ui/statusline/default.lua
@@ -103,16 +103,11 @@ end
 
 -- LSP STUFF
 M.LSP_progress = function()
-  if not rawget(vim, "lsp") then
+  if not rawget(vim, "lsp") or vim.lsp.status then
     return ""
   end
 
-  local Lsp
-  if vim.lsp.status then
-    Lsp = vim.lsp.status()
-  else
-    Lsp = vim.lsp.util.get_progress_messages()[1]
-  end
+  local Lsp = vim.lsp.util.get_progress_messages()[1]
 
   if vim.o.columns < 120 or not Lsp then
     return ""

--- a/lua/nvchad_ui/statusline/minimal.lua
+++ b/lua/nvchad_ui/statusline/minimal.lua
@@ -109,16 +109,11 @@ end
 
 -- LSP STUFF
 M.LSP_progress = function()
-  if not rawget(vim, "lsp") then
+  if not rawget(vim, "lsp") or vim.lsp.status then
     return ""
   end
 
-  local Lsp
-  if vim.lsp.status then
-    Lsp = vim.lsp.status()
-  else
-    Lsp = vim.lsp.util.get_progress_messages()[1]
-  end
+  local Lsp = vim.lsp.util.get_progress_messages()[1]
 
   if vim.o.columns < 120 or not Lsp then
     return ""

--- a/lua/nvchad_ui/statusline/minimal.lua
+++ b/lua/nvchad_ui/statusline/minimal.lua
@@ -113,7 +113,12 @@ M.LSP_progress = function()
     return ""
   end
 
-  local Lsp = vim.lsp.util.get_progress_messages()[1]
+  local Lsp
+  if vim.lsp.status then
+    Lsp = vim.lsp.status()
+  else
+    Lsp = vim.lsp.util.get_progress_messages()[1]
+  end
 
   if vim.o.columns < 120 or not Lsp then
     return ""

--- a/lua/nvchad_ui/statusline/vscode.lua
+++ b/lua/nvchad_ui/statusline/vscode.lua
@@ -98,7 +98,12 @@ M.LSP_progress = function()
     return ""
   end
 
-  local Lsp = vim.lsp.util.get_progress_messages()[1]
+  local Lsp
+  if vim.lsp.status then
+    Lsp = vim.lsp.status()
+  else
+    Lsp = vim.lsp.util.get_progress_messages()[1]
+  end
 
   if vim.o.columns < 120 or not Lsp then
     return ""

--- a/lua/nvchad_ui/statusline/vscode.lua
+++ b/lua/nvchad_ui/statusline/vscode.lua
@@ -94,16 +94,11 @@ end
 
 -- LSP STUFF
 M.LSP_progress = function()
-  if not rawget(vim, "lsp") then
+  if not rawget(vim, "lsp") or vim.lsp.status then
     return ""
   end
 
-  local Lsp
-  if vim.lsp.status then
-    Lsp = vim.lsp.status()
-  else
-    Lsp = vim.lsp.util.get_progress_messages()[1]
-  end
+  local Lsp = vim.lsp.util.get_progress_messages()[1]
 
   if vim.o.columns < 120 or not Lsp then
     return ""

--- a/lua/nvchad_ui/statusline/vscode_colored.lua
+++ b/lua/nvchad_ui/statusline/vscode_colored.lua
@@ -102,7 +102,12 @@ M.LSP_progress = function()
     return ""
   end
 
-  local Lsp = vim.lsp.util.get_progress_messages()[1]
+  local Lsp
+  if vim.lsp.status then
+    Lsp = vim.lsp.status()
+  else
+    Lsp = vim.lsp.util.get_progress_messages()[1]
+  end
 
   if vim.o.columns < 120 or not Lsp then
     return ""

--- a/lua/nvchad_ui/statusline/vscode_colored.lua
+++ b/lua/nvchad_ui/statusline/vscode_colored.lua
@@ -98,16 +98,11 @@ end
 
 -- LSP STUFF
 M.LSP_progress = function()
-  if not rawget(vim, "lsp") then
+  if not rawget(vim, "lsp") or vim.lsp.status then
     return ""
   end
 
-  local Lsp
-  if vim.lsp.status then
-    Lsp = vim.lsp.status()
-  else
-    Lsp = vim.lsp.util.get_progress_messages()[1]
-  end
+  local Lsp = vim.lsp.util.get_progress_messages()[1]
 
   if vim.o.columns < 120 or not Lsp then
     return ""
@@ -164,7 +159,7 @@ M.cursor_position = function()
   return vim.o.columns > 140 and "%#StText# Ln %l, Col %c  " or ""
 end
 
-M.file_encoding = function ()
+M.file_encoding = function()
   return string.upper(vim.bo.fileencoding) == "" and "" or "%#St_encode#" .. string.upper(vim.bo.fileencoding) .. "  "
 end
 


### PR DESCRIPTION
see the deprecation PR here:
> https://github.com/neovim/neovim/pull/23958

this simply replaces the status line fetch so that it will suppress warnings on new nvim installs