### PR TITLE
Make the statusline addable by the user module

### DIFF
--- a/lua/nvchad_ui/statusline/default.lua
+++ b/lua/nvchad_ui/statusline/default.lua
@@ -180,22 +180,44 @@ M.run = function()
   local modules = require "nvchad_ui.statusline.default"
 
   if config.overriden_modules then
-    modules = vim.tbl_deep_extend("force", modules, config.overriden_modules())
+    modules = vim.tbl_deep_extend("force", modules, config.overriden_modules(modules))
+  end
+
+  local segments = {
+    left = {
+      modules.mode,
+      modules.fileInfo,
+      modules.git,
+    },
+
+    mid = {
+      modules.LSP_progress,
+    },
+
+    right = {
+      modules.LSP_Diagnostics,
+      modules.LSP_status,
+      modules.cwd,
+      modules.cursor_position,
+    },
+  }
+
+  if config.user_modules then
+    segments = vim.tbl_deep_extend("force", segments, config.user_modules(segments))
+  end
+
+  for i, value in pairs(segments) do
+    for j, func in ipairs(value) do
+      segments[i][j] = func() or ""
+    end
   end
 
   return table.concat {
-    modules.mode(),
-    modules.fileInfo(),
-    modules.git(),
-
+    table.concat(segments.left),
     "%=",
-    modules.LSP_progress(),
+    table.concat(segments.mid),
     "%=",
-
-    modules.LSP_Diagnostics(),
-    modules.LSP_status() or "",
-    modules.cwd(),
-    modules.cursor_position(),
+    table.concat(segments.right),
   }
 end
 

--- a/lua/nvchad_ui/statusline/minimal.lua
+++ b/lua/nvchad_ui/statusline/minimal.lua
@@ -182,23 +182,45 @@ M.run = function()
   local modules = require "nvchad_ui.statusline.minimal"
 
   if config.overriden_modules then
-    modules = vim.tbl_deep_extend("force", modules, config.overriden_modules())
+    modules = vim.tbl_deep_extend("force", modules, config.overriden_modules(modules))
+  end
+
+  local segments = {
+    left = {
+      modules.mode,
+      modules.fileInfo,
+      modules.git,
+    },
+
+    mid = {
+      modules.LSP_progress,
+    },
+
+    right = {
+      modules.file_encoding,
+      modules.LSP_Diagnostics,
+      modules.LSP_status,
+      modules.cwd,
+      modules.cursor_position,
+    },
+  }
+
+  if config.user_modules then
+    segments = vim.tbl_deep_extend("force", segments, config.user_modules(segments))
+  end
+
+  for i, value in pairs(segments) do
+    for j, func in ipairs(value) do
+      segments[i][j] = func() or ""
+    end
   end
 
   return table.concat {
-    modules.mode(),
-    modules.fileInfo(),
-    modules.git(),
-
+    table.concat(segments.left),
     "%=",
-    modules.LSP_progress(),
+    table.concat(segments.mid),
     "%=",
-
-    modules.file_encoding(),
-    modules.LSP_Diagnostics(),
-    modules.LSP_status() or "",
-    modules.cwd(),
-    modules.cursor_position(),
+    table.concat(segments.right),
   }
 end
 

--- a/lua/nvchad_ui/statusline/vscode_colored.lua
+++ b/lua/nvchad_ui/statusline/vscode_colored.lua
@@ -172,25 +172,47 @@ M.run = function()
   local modules = require "nvchad_ui.statusline.vscode_colored"
 
   if config.overriden_modules then
-    modules = vim.tbl_deep_extend("force", modules, config.overriden_modules())
+    modules = vim.tbl_deep_extend("force", modules, config.overriden_modules(modules))
+  end
+
+  local segments = {
+    left = {
+      modules.mode,
+      modules.fileInfo,
+      modules.git,
+      modules.LSP_Diagnostics,
+    },
+
+    mid = {
+      modules.LSP_progress,
+    },
+
+    right = {
+      modules.gitchanges,
+      modules.cursor_position,
+      modules.file_encoding,
+      modules.filetype,
+      modules.LSP_status,
+      modules.cwd,
+    },
+  }
+
+  if config.user_modules then
+    segments = vim.tbl_deep_extend("force", segments, config.user_modules(segments))
+  end
+
+  for i, value in pairs(segments) do
+    for j, func in ipairs(value) do
+      segments[i][j] = func() or ""
+    end
   end
 
   return table.concat {
-    modules.mode(),
-    modules.fileInfo(),
-    modules.git(),
-    modules.LSP_Diagnostics(),
-
+    table.concat(segments.left),
     "%=",
-    modules.LSP_progress(),
+    table.concat(segments.mid),
     "%=",
-
-    modules.gitchanges(),
-    modules.cursor_position(),
-    modules.file_encoding(),
-    modules.filetype(),
-    modules.LSP_status() or "",
-    modules.cwd(),
+    table.concat(segments.right),
   }
 end
 


### PR DESCRIPTION
Sometimes users want to add their own custom module instead of replacing the existing one. So I made each statusline module in an array for users to add.

so the config file could be like this
```lua
statusline = {
  theme = "vscode_colored",
  overriden_modules = function(st_modules)
    -- i removed the `require` and changed it to the `st_modules` parameter
    -- st_modules this is just default table of statusline modules
    return {
      mode = function()
        return st_modules.mode() .. " bruh "
        -- or just return "" to hide this module
      end,
    }
  end,
  user_modules = function(st_modules)
    local m = st_modules.left
    local foo = function ()
      return " barr "
    end
    table.insert(m, 1, foo)
    -- i don't know any solution except using this method
    return {
      left = m,
    }
  end,
},
```

so the result will be like this

![gambar](https://github.com/NvChad/ui/assets/87700127/1398d451-759f-4b64-bbb5-a38269a966ee)