### PR TITLE
Fix bug in cheatsheet

### DIFF
--- a/lua/nvchad/cheatsheet/grid.lua
+++ b/lua/nvchad/cheatsheet/grid.lua
@@ -6,8 +6,10 @@ local isValid_mapping_TB = require("nvchad.cheatsheet").isValid_mapping_TB
 
 -- filter mappings_tb i.e remove tb which have empty fields
 for title, val in pairs(mappings_tb) do
-  if not isValid_mapping_TB(val) then
-    mappings_tb[title] = nil
+  for mode, mappings in pairs(val) do
+    if not isValid_mapping_TB(mappings) then
+      mappings_tb[title][mode] = nil
+    end
   end
 end
 

--- a/lua/nvchad/cheatsheet/init.lua
+++ b/lua/nvchad/cheatsheet/init.lua
@@ -17,15 +17,11 @@ M.getLargestWin = function()
 end
 
 M.isValid_mapping_TB = function(tbl)
-  local isEmpty = true
-
-  for _, value in pairs(tbl) do
-    if type(value) == "table" and #vim.tbl_keys(value) == 0 then
-      isEmpty = false
-    end
+  if type(tbl) ~= "table" or #vim.tbl_keys(tbl) == 0 then
+    return false
   end
 
-  return isEmpty
+  return true
 end
 
 return M

--- a/lua/nvchad/cheatsheet/simple.lua
+++ b/lua/nvchad/cheatsheet/simple.lua
@@ -3,8 +3,10 @@ local isValid_mapping_TB = require("nvchad.cheatsheet").isValid_mapping_TB
 
 -- filter mappings_tb i.e remove tb which have empty fields
 for title, val in pairs(mappings_tb) do
-  if not isValid_mapping_TB(val) then
-    mappings_tb[title] = nil
+  for mode, mappings in pairs(val) do
+    if not isValid_mapping_TB(mappings) then
+      mappings_tb[title][mode] = nil
+    end
   end
 end
 


### PR DESCRIPTION
There is a bug in the Lua code for NvCheatsheet that causes entire groups in the cheatsheet to disappear if all of the mappings for a particular mode are disabled. For example, if all of the mappings for insert mode in the `general` group are disabled, all sections in the `general` group (normal, visual, *etc*.) will be removed. These changes fix the logic to only remove the sections for modes that no longer have any mappings.