### PR TITLE
Add support to nvim-web-devicons prefixes to Tabufline

### DIFF
--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -52,7 +52,25 @@ end
 
 local function add_fileInfo(name, bufnr)
   if devicons_present then
-    local icon, icon_hl = devicons.get_icon(name, string.match(name, "%a+$"))
+    local supported_prefixes = {
+      "config.ru",
+      "test.jsx?",
+      "test.tsx?",
+      "spec.jsx?",
+      "spec.tsx?",
+    }
+
+    local prefix = ""
+
+    -- check if prefix should be used and if so get the right one
+    for _, supported_prefix in ipairs(supported_prefixes) do
+      local prefix_match = string.match(name, supported_prefix)
+      if (prefix_match) then
+        prefix = string.match(prefix_match, "%a+.")
+      end
+    end
+
+    local icon, icon_hl = devicons.get_icon(name, string.match(name, prefix .. "%a+$"))
 
     if not icon then
       icon = "󰈚"


### PR DESCRIPTION
[nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) provides a list of prefixes to complement common file extensions (e.g: `test.ts` instead of just `ts`).
The list is available [here](https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons.lua).

Then:
![image](https://github.com/NvChad/ui/assets/58279735/454e189a-547b-417b-8354-e3ff24a56b76)

Now:
![image](https://github.com/NvChad/ui/assets/58279735/df7d3329-2c71-4ea1-80bc-f6efa6fac88d)

The sandbox I used to test it can be accessed [here](https://onecompiler.com/lua/3zkaxju6z).

- - -

Please let me know if any changes are needed ;)