### PR TITLE
fix nvim-web-devicons filename in tabufline

### DIFF
--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -52,7 +52,7 @@ end
 
 local function add_fileInfo(name, bufnr)
   if devicons_present then
-    local icon, icon_hl = devicons.get_icon(name, string.match(name, "%a+$"))
+    local icon, icon_hl = devicons.get_icon(name)
 
     if not icon then
       icon = "󰈚"


### PR DESCRIPTION
It is not correct to have different behaviours in Tabufline and Statusline regarding the nvim-web-devicons `get_icon` call.

For `Statusline`, it [passes the whole expanded filename](https://github.com/NvChad/ui/blob/v2.0/lua/nvchad/statusline/default.lua#L79) using `%:t`, but for `Tabufline`, it [uses a regex to pass just the file extension](https://github.com/NvChad/ui/blob/v2.0/lua/nvchad/tabufline/modules.lua#L55), even though nvim-web-devicons supports passing everything to find the icon.

To fix this, the regex is removed, passing the whole filename passed through the `add_fileInfo` function to `get_icon` call.

- - - -

*Different* approach to fix #181.

**Note:** I'm not only "targetting js/ts stuff" because it also fixes the problem for `config.ru` for **Ruby**. Again, all the prefixes are available [here](https://github.com/nvim-tree/nvim-web-devicons/blob/master/lua/nvim-web-devicons.lua).

Then:
![image](https://github.com/NvChad/ui/assets/58279735/454e189a-547b-417b-8354-e3ff24a56b76)

Now:
![image](https://github.com/NvChad/ui/assets/58279735/df7d3329-2c71-4ea1-80bc-f6efa6fac88d)