### PR TITLE
Allow overriding of vim.diagnostic.config options in M.ui

### DIFF
--- a/lua/nvchad/lsp.lua
+++ b/lua/nvchad/lsp.lua
@@ -1,3 +1,5 @@
+local config = require("core.utils").load_config().ui
+
 local function lspSymbol(name, icon)
   local hl = "DiagnosticSign" .. name
   vim.fn.sign_define(hl, { text = icon, numhl = hl, texthl = hl })
@@ -8,7 +10,7 @@ lspSymbol("Info", "󰋼")
 lspSymbol("Hint", "󰌵")
 lspSymbol("Warn", "")
 
-vim.diagnostic.config {
+local diagnostic_config = {
   virtual_text = {
     prefix = "",
   },
@@ -16,6 +18,14 @@ vim.diagnostic.config {
   underline = true,
   update_in_insert = false,
 }
+
+if config.diagnostic_config ~= nil then
+  for k, v in pairs(config.diagnostic_config) do
+    diagnostic_config[k] = v
+  end
+end
+
+vim.diagnostic.config(diagnostic_config)
 
 vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(vim.lsp.handlers.hover, {
   border = "single",

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -58,6 +58,12 @@
 ---@field lsp_semantic_tokens? boolean
 --- List of extras themes for other plugins not in NvChad that you want to compile
 ---@field extended_integrations? ExtendedModules[]
+---@field diagnostic_config? table
+--- A table of overrides for vim.diagnostic.config
+--- Example:
+--- ```lua
+---     diagnostic_config = { virtual_text = false }
+--- ```
 
 --- Options for stylings of nvim-cmp 
 ---@class NvCmpConfig


### PR DESCRIPTION
Adds in the ability to override the options to vim.diagnostic.config for LSPs by adding a table to M.ui in chadrc.lua, e.g:

```
M.ui = {
  diagnostic_config = {
    virtual_text = false
  }
}
```

The defaults remain unchanged.