### PR TITLE
add illuminate on ExtendedModules

### DIFF
--- a/nvchad_types/all_hl_groups.lua
+++ b/nvchad_types/all_hl_groups.lua
@@ -606,3 +606,4 @@ error("Requring a meta file")
 ---| "'rainbowdelimiters'"
 ---| "'todo'"
 ---| "'trouble'"
+---| "'illuminate'"


### PR DESCRIPTION
Related to [my other PR to add suport of vim-illumnate on base46 extended_integration](https://github.com/NvChad/base46/pull/258), this adds `illuminate` on ExtendedModules`.