### PR TITLE
fix #206 renamer error when using lua keyword as variable name

### DIFF
--- a/lua/nvchad/renamer.lua
+++ b/lua/nvchad/renamer.lua
@@ -2,6 +2,7 @@
 -- This is modified version of the above snippet
 
 local M = {}
+local map = vim.keymap.set
 
 M.open = function()
   local currName = vim.fn.expand "<cword>" .. " "
@@ -20,29 +21,15 @@ M.open = function()
     col = "cursor-1",
   })
 
-  local map_opts = { noremap = true, silent = true }
-
   vim.cmd "normal w"
   vim.cmd "startinsert"
 
-  vim.api.nvim_buf_set_keymap(0, "i", "<Esc>", "<cmd>stopinsert | q!<CR>", map_opts)
-  vim.api.nvim_buf_set_keymap(0, "n", "<Esc>", "<cmd>stopinsert | q!<CR>", map_opts)
+  map({ "i", "n" }, "<Esc>", "<cmd>q<CR>", { buffer = 0 })
 
-  vim.api.nvim_buf_set_keymap(
-    0,
-    "i",
-    "<CR>",
-    "<cmd>stopinsert | lua require'nvchad.renamer'.apply(" .. "'" .. currName .. "'" .. "," .. win .. ")<CR>",
-    map_opts
-  )
-
-  vim.api.nvim_buf_set_keymap(
-    0,
-    "n",
-    "<CR>",
-    "<cmd>stopinsert | lua require'nvchad.renamer'.apply(" .. "'" .. currName .. "'" .. "," .. win .. ")<CR>",
-    map_opts
-  )
+  map({ "i", "n" }, "<CR>", function()
+    require("nvchad.renamer").apply(currName, win)
+    vim.cmd.stopinsert()
+  end, { buffer = 0 })
 end
 
 M.apply = function(curr, win)

--- a/lua/nvchad/renamer.lua
+++ b/lua/nvchad/renamer.lua
@@ -32,7 +32,7 @@ M.open = function()
     0,
     "i",
     "<CR>",
-    "<cmd>stopinsert | lua require'nvchad.renamer'.apply(" .. currName .. "," .. win .. ")<CR>",
+    "<cmd>stopinsert | lua require'nvchad.renamer'.apply(" .. "'" .. currName .. "'" .. "," .. win .. ")<CR>",
     map_opts
   )
 
@@ -40,7 +40,7 @@ M.open = function()
     0,
     "n",
     "<CR>",
-    "<cmd>stopinsert | lua require'nvchad.renamer'.apply(" .. currName .. "," .. win .. ")<CR>",
+    "<cmd>stopinsert | lua require'nvchad.renamer'.apply(" .. "'" .. currName .. "'" .. "," .. win .. ")<CR>",
     map_opts
   )
 end


### PR DESCRIPTION
This is a quick fix #206 for using lua keyword as variable name and rename them. The renamer might require some more advanced escaping policy, since I simply add quotes so code injection is still possible.