### PR TITLE
Added functionality to display either file name, absolute, or relative path in statusline.

### DIFF
--- a/lua/nvchad/statusline/default.lua
+++ b/lua/nvchad/statusline/default.lua
@@ -83,8 +83,13 @@ end
 -- credits to ii14 for str:match func
 M.fileInfo = function()
   local icon = " 󰈚 "
-  local path = vim.api.nvim_buf_get_name(stbufnr())
-  local name = (path == "" and "Empty ") or path:match "([^/\\]+)[/\\]*$"
+  local absolute_path = vim.api.nvim_buf_get_name(stbufnr())
+  local filename_types = {
+    absolute = absolute_path,
+    relative = vim.fn.fnamemodify(absolute_path, ":."),
+    name = absolute_path:match "([^/\\]+)[/\\]*$",
+  }
+  local name = (absolute_path == "" and "Empty ") or filename_types[config.filename_type]
 
   if name ~= "Empty " then
     local devicons_present, devicons = pcall(require, "nvim-web-devicons")

--- a/lua/nvchad/statusline/default.lua
+++ b/lua/nvchad/statusline/default.lua
@@ -84,12 +84,12 @@ end
 M.fileInfo = function()
   local icon = " 󰈚 "
   local absolute_path = vim.api.nvim_buf_get_name(stbufnr())
-  local filename_types = {
+  local filename_styles = {
     absolute = absolute_path,
     relative = vim.fn.fnamemodify(absolute_path, ":."),
     name = absolute_path:match "([^/\\]+)[/\\]*$",
   }
-  local name = (absolute_path == "" and "Empty ") or filename_types[config.filename_type]
+  local name = (absolute_path == "" and "Empty ") or filename_styles[config.filename_style]
 
   if name ~= "Empty " then
     local devicons_present, devicons = pcall(require, "nvim-web-devicons")

--- a/lua/nvchad/statusline/minimal.lua
+++ b/lua/nvchad/statusline/minimal.lua
@@ -91,12 +91,12 @@ end
 M.fileInfo = function()
   local icon = "󰈚"
   local absolute_path = vim.api.nvim_buf_get_name(stbufnr())
-  local filename_types = {
+  local filename_styles = {
     absolute = absolute_path,
     relative = vim.fn.fnamemodify(absolute_path, ":."),
     name = absolute_path:match "([^/\\]+)[/\\]*$",
   }
-  local name = (absolute_path == "" and "Empty ") or filename_types[config.filename_type]
+  local name = (absolute_path == "" and "Empty ") or filename_styles[config.filename_style]
 
   if name ~= "Empty " then
     local devicons_present, devicons = pcall(require, "nvim-web-devicons")

--- a/lua/nvchad/statusline/minimal.lua
+++ b/lua/nvchad/statusline/minimal.lua
@@ -90,8 +90,13 @@ end
 
 M.fileInfo = function()
   local icon = "󰈚"
-  local path = vim.api.nvim_buf_get_name(stbufnr())
-  local name = (path == "" and "Empty ") or path:match "([^/\\]+)[/\\]*$"
+  local absolute_path = vim.api.nvim_buf_get_name(stbufnr())
+  local filename_types = {
+    absolute = absolute_path,
+    relative = vim.fn.fnamemodify(absolute_path, ":."),
+    name = absolute_path:match "([^/\\]+)[/\\]*$",
+  }
+  local name = (absolute_path == "" and "Empty ") or filename_types[config.filename_type]
 
   if name ~= "Empty " then
     local devicons_present, devicons = pcall(require, "nvim-web-devicons")

--- a/lua/nvchad/statusline/vscode.lua
+++ b/lua/nvchad/statusline/vscode.lua
@@ -67,12 +67,12 @@ end
 M.fileInfo = function()
   local icon = "󰈚 "
   local absolute_path = vim.api.nvim_buf_get_name(stbufnr())
-  local filename_types = {
+  local filename_styles = {
     absolute = absolute_path,
     relative = vim.fn.fnamemodify(absolute_path, ":."),
     name = absolute_path:match "([^/\\]+)[/\\]*$",
   }
-  local name = (absolute_path == "" and "Empty ") or filename_types[config.filename_type]
+  local name = (absolute_path == "" and "Empty ") or filename_styles[config.filename_style]
 
   if name ~= "Empty " then
     local devicons_present, devicons = pcall(require, "nvim-web-devicons")

--- a/lua/nvchad/statusline/vscode.lua
+++ b/lua/nvchad/statusline/vscode.lua
@@ -66,8 +66,13 @@ end
 
 M.fileInfo = function()
   local icon = "󰈚 "
-  local path = vim.api.nvim_buf_get_name(stbufnr())
-  local name = (path == "" and "Empty ") or path:match "([^/\\]+)[/\\]*$"
+  local absolute_path = vim.api.nvim_buf_get_name(stbufnr())
+  local filename_types = {
+    absolute = absolute_path,
+    relative = vim.fn.fnamemodify(absolute_path, ":."),
+    name = absolute_path:match "([^/\\]+)[/\\]*$",
+  }
+  local name = (absolute_path == "" and "Empty ") or filename_types[config.filename_type]
 
   if name ~= "Empty " then
     local devicons_present, devicons = pcall(require, "nvim-web-devicons")

--- a/lua/nvchad/statusline/vscode_colored.lua
+++ b/lua/nvchad/statusline/vscode_colored.lua
@@ -67,12 +67,12 @@ end
 M.fileInfo = function()
   local icon = "󰈚 "
   local absolute_path = vim.api.nvim_buf_get_name(stbufnr())
-  local filename_types = {
+  local filename_styles = {
     absolute = absolute_path,
     relative = vim.fn.fnamemodify(absolute_path, ":."),
     name = absolute_path:match "([^/\\]+)[/\\]*$",
   }
-  local name = (absolute_path == "" and "Empty ") or filename_types[config.filename_type]
+  local name = (absolute_path == "" and "Empty ") or filename_styles[config.filename_style]
 
   if name ~= "Empty " then
     local devicons_present, devicons = pcall(require, "nvim-web-devicons")

--- a/lua/nvchad/statusline/vscode_colored.lua
+++ b/lua/nvchad/statusline/vscode_colored.lua
@@ -66,8 +66,13 @@ end
 
 M.fileInfo = function()
   local icon = "󰈚 "
-  local path = vim.api.nvim_buf_get_name(stbufnr())
-  local name = (path == "" and "Empty ") or path:match "([^/\\]+)[/\\]*$"
+  local absolute_path = vim.api.nvim_buf_get_name(stbufnr())
+  local filename_types = {
+    absolute = absolute_path,
+    relative = vim.fn.fnamemodify(absolute_path, ":."),
+    name = absolute_path:match "([^/\\]+)[/\\]*$",
+  }
+  local name = (absolute_path == "" and "Empty ") or filename_types[config.filename_type]
 
   if name ~= "Empty " then
     local devicons_present, devicons = pcall(require, "nvim-web-devicons")

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -89,7 +89,7 @@
 --- Maximum length for the progress messages section
 ---@field lspprogress_len? integer
 --- How the name of the currently open file is displayed
----@field filename_type? '"name"'|'"relative"'|'"absolute"'
+---@field filename_style? '"name"'|'"relative"'|'"absolute"'
 
 --- Options for NvChad Tabufline
 ---@class NvTabLineConfig

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -88,6 +88,8 @@
 ---@field overriden_modules? fun(modules: table)
 --- Maximum length for the progress messages section
 ---@field lspprogress_len? integer
+--- How the name of the currently open file is displayed
+---@field filename_type? '"name"'|'"relative"'|'"absolute"'
 
 --- Options for NvChad Tabufline
 ---@class NvTabLineConfig


### PR DESCRIPTION
### Description
Added the option to choose how the file name is displayed in the statusline. The `filename_type` option in `NvStatusLineConfig` can be `"name"|"relative"|"absolute"` and sets how the file name is displayed.

### Appearance
It works with all the themes currently supported by statusline.
#### default and minimal
|             | default                                                                                     | minimal                                                                                      |
|-------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
| name        | ![image](https://github.com/NvChad/ui/assets/61359702/4f6c8381-5423-4be2-b7f5-664e68b428bc) | ![image](https://github.com/NvChad/ui/assets/61359702/fee3ff00-6d59-4e68-a62b-2c4d951abdc2) |
| relative    | ![image](https://github.com/NvChad/ui/assets/61359702/67564e87-61a9-488a-a606-d77e68315e21) | ![image](https://github.com/NvChad/ui/assets/61359702/23df9146-e5ae-44da-9658-02645b5af3a3) |
| absolute    | ![image](https://github.com/NvChad/ui/assets/61359702/96b2aa4e-85c7-4984-abbb-d5c526375d7f) | ![image](https://github.com/NvChad/ui/assets/61359702/90cdcad6-b9c2-42a7-a819-1e598fd0660e) |

#### vscode and vscode_colored
|             | vscode                                                                                      | vscode_colored                                                                               |
|-------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
| name        | ![image](https://github.com/NvChad/ui/assets/61359702/12bff441-d021-41fb-912b-c23699dfe707) | ![image](https://github.com/NvChad/ui/assets/61359702/62f02b2b-4ee5-4f76-b39f-0591835dbdb2)   |
| relative    | ![image](https://github.com/NvChad/ui/assets/61359702/2c808ed3-fdef-4fbe-8acb-136954a6b038) | ![image](https://github.com/NvChad/ui/assets/61359702/5f0a5b46-cf40-4db8-9d8c-edf0f47fb0de)   |
| absolute    | ![image](https://github.com/NvChad/ui/assets/61359702/66a33365-95e6-4644-948e-02bc7beccbe3) | ![image](https://github.com/NvChad/ui/assets/61359702/b10ca7e9-5efa-4395-9a99-7e2206a12318)   |