### PR TITLE
add seperator, lsp feat to tabufline

### DIFF
--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -142,7 +142,7 @@ local function add_fileInfo(name, bufnr)
     -- padding around bufname; 24 = bufame length (icon + filename)
     local padding = (24 - #name - 5) / 2
     local maxname_len = 16
-    local seperator = tabufline_config.seperator and (isBufOn and "▎" or " ") or ""
+    local separator = tabufline_config.seperator and (isBufOn and "▎" or " ") or ""
     local diagnostics = tabufline_config.diagnostics and LspDiagnostics() or ""
 
     name = (#name > maxname_len and string.sub(name, 1, 14) .. "..") or name
@@ -153,7 +153,7 @@ local function add_fileInfo(name, bufnr)
       or ("%#TbLineBufOff# " .. name)
     )
 
-    return seperator .. string.rep(" ", padding) .. icon .. name .. string.rep(" ", padding) .. diagnostics
+    return separator .. string.rep(" ", padding) .. icon .. name .. string.rep(" ", padding) .. diagnostics
   end
 end
 

--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -142,7 +142,7 @@ local function add_fileInfo(name, bufnr)
     -- padding around bufname; 24 = bufame length (icon + filename)
     local padding = (24 - #name - 5) / 2
     local maxname_len = 16
-    local separator = tabufline_config.seperator and (isBufOn and "▎" or " ") or ""
+    local indicator = tabufline_config.seperator and (isBufOn and "▎" or " ") or ""
     local diagnostics = tabufline_config.diagnostics and LspDiagnostics() or ""
 
     name = (#name > maxname_len and string.sub(name, 1, 14) .. "..") or name
@@ -153,7 +153,7 @@ local function add_fileInfo(name, bufnr)
       or ("%#TbLineBufOff# " .. name)
     )
 
-    return separator .. string.rep(" ", padding) .. icon .. name .. string.rep(" ", padding) .. diagnostics
+    return indicator .. string.rep(" ", padding) .. icon .. name .. string.rep(" ", padding) .. diagnostics
   end
 end
 

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -59,7 +59,7 @@
 --- List of extras themes for other plugins not in NvChad that you want to compile
 ---@field extended_integrations? ExtendedModules[]
 
---- Options for stylings of nvim-cmp 
+--- Options for stylings of nvim-cmp
 ---@class NvCmpConfig
 --- Whether to add colors to icons in nvim-cmp popup menu
 ---@field icons? boolean
@@ -102,9 +102,13 @@
 ---@field overriden_modules? fun(modules: table)
 --- Show numbers on tabufline buffer tabs
 --- @field show_numbers? boolean
+--- enable lsp diagnostics
+---@field diagnostics? boolean
+--- add a left line to the current buffer
+---@field indicator? boolean
 
 ---@class NvDashboardConfig
---- Whether to open dashboard on opening nvim 
+--- Whether to open dashboard on opening nvim
 ---@field load_on_startup? boolean
 --- Your ascii art
 --- Each string is one line
@@ -122,7 +126,7 @@
 ---@field [3] string|fun() A Vim Command/A Lua function to be triggered when pressing the keybind/pressing enter on the line with the description on the dashboard
 
 ---Options for NvChad/ui lsp configuration
----@class NvLspConfig 
+---@class NvLspConfig
 ---@field signature? NvLspSignatureConfig Opts for showing function signatures as you type
 
 ---@class NvLspSignatureConfig
@@ -164,7 +168,7 @@
 --- @field gitsigns?   KeymapsTable Keymaps for gitsigns.nvim
 
 --- List of keymaps that is part of `core/mappings.lua` that will be removed
----@class DisabledTable 
+---@class DisabledTable
 ---@field n?   table<string, '""'|false> Normal Mode keymaps to remove
 ---@field x?   table<string, '""'|false> Visual Mode keymaps to remove
 ---@field s?   table<string, '""'|false> Select Mode keymaps to remove


### PR DESCRIPTION
this PR adds a two features to the `tabufline` plugin.

- lsp support
  - adding status updates to identify errors and warnings etc.. while switching or editing a buffer.
  - the `hint` and `info` (icons and nums) is not included.
  - this will add four new highlights (I couldn't any similar highlights except statusline hls), `TblineError`, `TblineWarning`, 
`TblineHint`, `TblineInfo`
  - and it would be great if the `TbLineBufOn` highlight had italic and bold styles

- separator
  - A simple line separator can be added to better highlight the current buffer. Users often use transparency which can make it hard to identify the current buffer.
  - it would be great if there was an option to further customize the separator icon.

**Note that will be add two options in the tabufline config `diagnostics` and `seperator`**

Preview:
![preview](https://github.com/NvChad/ui/assets/116302048/6f71a332-c1df-4045-bdfb-9da0e8c40d24)
