### PR TITLE
Remove unlisted buffers from `M.bufilter`

### DIFF
--- a/lua/nvchad/tabufline/init.lua
+++ b/lua/nvchad/tabufline/init.lua
@@ -12,9 +12,8 @@ M.bufilter = function()
     local is_valid = vim.api.nvim_buf_is_valid(nr)
     -- NOTE: It is important to remove unlisted buffers from the list otherwise
     -- it may cause an error when trying to switch to them.
-    local is_listed = vim.api.nvim_buf_get_option(nr, 'buflisted')
-    local should_remove = not is_valid or not is_listed
-    if should_remove then table.remove(bufs, i) end
+    local is_listed = vim.api.nvim_get_option_value('buflisted', {buf = nr})
+    if not is_valid or not is_listed then table.remove(bufs, i) end
   end
 
   vim.t.bufs = bufs

--- a/lua/nvchad/tabufline/init.lua
+++ b/lua/nvchad/tabufline/init.lua
@@ -9,9 +9,12 @@ M.bufilter = function()
   end
 
   for i, nr in ipairs(bufs) do
-    if not vim.api.nvim_buf_is_valid(nr) then
-      table.remove(bufs, i)
-    end
+    local is_valid = vim.api.nvim_buf_is_valid(nr)
+    -- NOTE: It is important to remove unlisted buffers from the list otherwise
+    -- it may cause an error when trying to switch to them.
+    local is_listed = vim.api.nvim_buf_get_option(nr, 'buflisted')
+    local should_remove = not is_valid or not is_listed
+    if should_remove then table.remove(bufs, i) end
   end
 
   vim.t.bufs = bufs


### PR DESCRIPTION
I was running into an error when using [undotree](https://github.com/mbbill/undotree].

Whenever I:
- Toggled undotree (`<leader>u`)
- Closed undotree after picking my version (`q`)
- Pressed tab out (`<tab>`, essentially called `M.tabuflineNext`

I'd either see an error like:

```txt
E5108: Error executing lua: vim/_editor.lua:0: nvim_exec2()..BufEnter Autocommands for "<buffer=14>"..function 59[6]..<SNR>38_exec, line 2: Vim(quit):E37: No write since last change
stack traceback:
        [C]: in function 'nvim_exec2'
        vim/_editor.lua: in function 'cmd'
        .../.local/share/nvim/lazy/ui/lua/nvchad/tabufline/init.lua:38: in function 'tabuflineNext'
        ~.config/nvim/lua/core/mappings.lua:84: in function <~/.config/nvim/lua/core/mappings.lua:83>
```

Or `nvim` would just outright close... upon further investigation I noticed that we were essentially trying to tab into a buffer that was unlisted, in my case the "diff" tab of undotree.

I fiddled around and figured that for `tabufline` we're probably safe to ignore such buffers? I speak without any assumptions/authority as I have essentially 0 experience with vim plugin development, but this seems to fix my issue!

Any feedback/suggestions/corrections welcome!