### PR TITLE
fix: Inconsistent buffer focus shift of term runner 

### DIFF
--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -142,6 +142,11 @@ M.runner = function(opts)
 
     local job_id = vim.b[x.buf].terminal_job_id
     vim.api.nvim_chan_send(job_id, clear_cmd .. cmd .. " \n")
+
+    local win = vim.fn.bufwinid(x.buf)
+    vim.fn.win_gotoid(win)
+    vim.cmd "startinsert"
+
   end
 end
 


### PR DESCRIPTION
Resolved an issue where focus did not shift to the runner buffer when executing commands in already existing visible buffers, unlike with new/invisible ones (which are handled with display() function). 