### PR TITLE
respect fields in config.order when calculating available space

### DIFF
--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -43,9 +43,9 @@ local M = {}
 local function available_space()
   local str = ""
 
-  for key, value in pairs(M) do
+  for _, key in ipairs(config.order) do
     if key ~= "buffers" then
-      str = str .. value()
+      str = str .. M[key]()
     end
   end
 


### PR DESCRIPTION
I have this fields in chardrc.lua (no treeOffset field) and available space for tabufline is not calculated correctly:

```
M.ui = {
    tabufline = {
        order = {
            "buffers",
            "tabs",
            "btns",
        },
    },
}
```

