### PR TITLE
Use vim loader to find path to chadrc file

### DIFF
--- a/lua/nvchad/utils.lua
+++ b/lua/nvchad/utils.lua
@@ -19,13 +19,12 @@ M.list_themes = function()
   return default_themes
 end
 
-M.replace_word = function(old, new)
-  local chadrc = vim.fn.stdpath "config" .. "/lua/" .. "chadrc.lua"
-  local file = io.open(chadrc, "r")
+M.replace_word = function(filename, old, new)
+  local file = io.open(filename, "r")
   local added_pattern = string.gsub(old, "-", "%%-") -- add % before - if exists
   local new_content = file:read("*all"):gsub(added_pattern, new)
 
-  file = io.open(chadrc, "w")
+  file = io.open(filename, "w")
   file:write(new_content)
   file:close()
 end

--- a/lua/telescope/_extensions/themes.lua
+++ b/lua/telescope/_extensions/themes.lua
@@ -63,10 +63,11 @@ local function switcher()
       ------------ save theme to chadrc on enter ----------------
       actions.select_default:replace(function()
         if action_state.get_selected_entry() then
-          local old_theme = dofile(vim.fn.stdpath "config" .. "/lua/chadrc.lua").ui.theme
+          local chadrc = vim.loader.find('chadrc')[1].modpath
+          local old_theme = dofile(chadrc).ui.theme
           local selected_theme = action_state.get_selected_entry()[1]
 
-          require("nvchad.utils").replace_word(old_theme, selected_theme)
+          require("nvchad.utils").replace_word(chadrc, old_theme, selected_theme)
           actions.close(prompt_bufnr)
         end
       end)


### PR DESCRIPTION
Neovim has a `vim.loader.find` function which will search the same way that `require` does.

Since chadrc is loaded by `require` lets use the same mechanism to update the contents when changing theme.

Without this if (like me) your chadrc isn't in a standard path then using the Telescope theme picker errored.