### PR TITLE
Add cr mode entry to statusline modes table

### DIFF
--- a/lua/nvchad/stl/utils.lua
+++ b/lua/nvchad/stl/utils.lua
@@ -71,6 +71,7 @@ M.modes = {
   ["c"] = { "COMMAND", "Command" },
   ["cv"] = { "COMMAND", "Command" },
   ["ce"] = { "COMMAND", "Command" },
+  ["cr"] = { "COMMAND", "Command" },
   ["r"] = { "PROMPT", "Confirm" },
   ["rm"] = { "MORE", "Confirm" },
   ["r?"] = { "CONFIRM", "Confirm" },


### PR DESCRIPTION
Fixed a bug where the statusline would crash when entering cr mode. 

This crash would occur because the mode function in `stl/default.lua` would receive nil when indexing into the `stl/utils.lua` "modes" table when the mode was "cr".