### PR TITLE
feat(ui) Added option to the terminal signcolumn as padding

### DIFF
--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -60,11 +60,14 @@ M.display = function(opts)
 
   vim.wo[win].number = false
   vim.wo[win].relativenumber = false
-  -- vim.wo[win].foldcolumn = "0"
-  -- vim.wo[win].signcolumn = "no"
   vim.bo[opts.buf].buflisted = false
   vim.wo[win].winhl = opts.hl or config.hl
   vim.cmd "startinsert"
+
+  if opts.padding == false or (not config.padding and opts.padding == nil) then
+    vim.wo[win].foldcolumn = "0"
+    vim.wo[win].signcolumn = "no"
+  end
 
   -- resize non floating wins initially + or only when they're toggleable
   if (opts.pos == "sp" and not vim.g.nvhterm) or (opts.pos == "vsp" and not vim.g.nvvterm) or (opts.pos ~= "float") then


### PR DESCRIPTION
## Running other terminals UI

If you would like to create a shortcut for a program that renders a UI, you're facing an issue with the `signcolumn`. To avoid this, add the `padding = false` option.

```lua
map({ "n", "i", "t" }, "<C-9>", function()
  require("nvchad.term").toggle {
    pos = "float",
    id = "k9s",
    cmd = "k9s",
    padding = false,
    float_opts = {
      width = 0.8,
      height = 0.8,
      row = 0.1,
      col = 0.1,
    }
  }
end)
```