### PR TITLE
fix(types): add neogit to Base46Integrations

### DIFF
--- a/nvchad_types/all_hl_groups.lua
+++ b/nvchad_types/all_hl_groups.lua
@@ -1127,6 +1127,7 @@ error("Requring a meta file")
 ---| "'mason'"
 ---| "'navic'"
 ---| "'notify'"
+---| "'neogit'"
 ---| "'nvcheatsheet'"
 ---| "'nvdash'"
 ---| "'nvimtree'"


### PR DESCRIPTION
This should clear the lsp diagnostic warning in chadrc
