### PR TITLE
feat: add botright split options for terminal position

### DIFF
--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -10,6 +10,8 @@ g.nvchad_terms = {}
 local pos_data = {
   sp = { resize = "height", area = "lines" },
   vsp = { resize = "width", area = "columns" },
+  ["bo sp"] = { resize = "height", area = "lines" },
+  ["bo vsp"] = { resize = "width", area = "columns" },
 }
 
 local config = require("nvconfig").ui.term


### PR DESCRIPTION
Allows `bo sp` and `bo vsp` options for `nvchad.term` module's `pos` option.

This PR enables this behavior: https://github.com/zbirenbaum/nvterm/issues/15

### example
```lua
local term = require("nvchad.term")

map('n', '<leader>v', function()
  term.toggle { pos = "bo vsp", id = "vertical", size = 0.25 }
end, { desc = "Terminal Toggle vertical terminal" })

map('n', '<leader>h', function()
  term.toggle { pos = "bo sp", id = "horizontal" }
end, { desc = "Terminal Toggle horizontal terminal" })
```