### PR TITLE
tabufline: fix incorrect buffer order post file write

### DIFF
--- a/lua/nvchad/tabufline/lazyload.lua
+++ b/lua/nvchad/tabufline/lazyload.lua
@@ -55,6 +55,25 @@ vim.api.nvim_create_autocmd({ "BufAdd", "BufEnter", "tabnew" }, {
   end,
 })
 
+-- preserve buffer order in tabufline on file write
+vim.api.nvim_create_autocmd("VimEnter", {
+  callback = function()
+    local bufs_new_order
+
+    vim.api.nvim_create_autocmd("BufWritePre", {
+      callback = function()
+        bufs_new_order = vim.t.bufs
+      end,
+    })
+
+    vim.api.nvim_create_autocmd("BufWritePost", {
+      callback = function()
+        vim.t.bufs = bufs_new_order
+      end,
+    })
+  end,
+})
+
 vim.api.nvim_create_autocmd("BufDelete", {
   callback = function(args)
     for _, tab in ipairs(vim.api.nvim_list_tabpages()) do


### PR DESCRIPTION
As mentioned in the discord server, this is intended to be a workaround that allows for a reliable usage of `move_buf` until the root cause of the bug is found, that is, `:w` hard resetting the values of `vim.t.bufs`