### PR TITLE
Fix: keep track of window id

### DIFF
--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -82,6 +82,7 @@ M.display = function(opts)
   end
 
   api.nvim_win_set_buf(win, opts.buf)
+  save_term_info(opts.buf, opts)
 end
 
 local function create(opts)


### PR DESCRIPTION
When using `toggle()` on a terminal spawned using `runner()`, a new window ID is assigned, but is not tracked, and so an error is thrown for an unknown window ID when attempting to `toggle()` again.

Found out about this when trying to assign a keybind to toggling a "runner" terminal
```lua
map({ "n", "t" }, "<A-r>", function()
  require("nvchad.term").toggle { id = "runner", pos = "float" }
end, { desc = "terminal show runner term" })
```
Then I used [desdic/greyjoy.nvim](https://github.com/desdic/greyjoy.nvim) to spawn a build job into this runner using the following.
```lua
nvterm.runner {
  pos = "float",
  cmd = commandstr,
  id = "runner",
  clear_cmd = false
}
```
With this, I kept getting the aforementioned error.