### PR TITLE
FIX(Signature): Add focusable=false back

### DIFF
--- a/lua/nvchad/lsp/signature.lua
+++ b/lua/nvchad/lsp/signature.lua
@@ -1,4 +1,7 @@
 local M = {}
+vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
+  focusable = false,
+})
 
 local function check_triggeredChars(triggerChars)
   local cur_line = vim.api.nvim_get_current_line()

--- a/lua/nvchad/lsp/signature.lua
+++ b/lua/nvchad/lsp/signature.lua
@@ -1,4 +1,5 @@
 local M = {}
+
 vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
   focusable = false,
 })


### PR DESCRIPTION
Fix cursor jumping to signature when typing by adding back
```lua
vim.lsp.handlers["textDocument/signatureHelp"] = vim.lsp.with(vim.lsp.handlers.signature_help, {
  focusable = false,
})
```