### PR TITLE
feat: add check while requiring chadrc in nvconfig.lua

### DIFF
--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -85,4 +85,5 @@ local options = {
   mason = { cmd = true, pkgs = {} },
 }
 
-return vim.tbl_deep_extend("force", options, require "chadrc")
+local status, chadrc = pcall(require, "chadrc")
+return vim.tbl_deep_extend("force", options, status and chadrc or {})

--- a/scripts/update-nvchad-types.lua
+++ b/scripts/update-nvchad-types.lua
@@ -1,11 +1,4 @@
 -- All credits to @lucario as he has made all of this type stuff
-
-local chadrc = pcall(require, "chadrc")
-
-if not chadrc then
-  package.loaded.chadrc = {}
-end
-
 local normalize = vim.fs.normalize
 local fnamemodify = vim.fn.fnamemodify
 -- local nvchad_types_fp = vim.fs.normalize(vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h"))


### PR DESCRIPTION
This ensures that the ci workflow for updating types in base46 runs properly, while also allowing nvconfig.lua to be called without the need of having a chadrc.lua file