### PR TITLE
Fix terminal shell with spaces

### DIFF
--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -89,7 +89,7 @@ local function create(opts)
 
   -- handle cmd opt
   local shell = vim.o.shell
-  local cmd = shell
+  local cmd = { shell }
 
   if opts.cmd and opts.buf then
     cmd = { shell, "-c", format_cmd(opts.cmd) .. "; " .. shell }

--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -89,10 +89,12 @@ local function create(opts)
 
   -- handle cmd opt
   local shell = vim.o.shell
-  local cmd = { shell }
+  local cmd = shell
 
   if opts.cmd and opts.buf then
     cmd = { shell, "-c", format_cmd(opts.cmd) .. "; " .. shell }
+  else
+    cmd = { shell }
   end
 
   M.display(opts)


### PR DESCRIPTION
Hello, I am a Windows user, and I use PowerShell with NeoVim configured through NvChad. I've customized my PowerShell setup and wanted to use these configurations in NvChad, but NvTerm defaults to cmd, which I don't prefer. So, I decided to modify the NvChad setup to manually configure it to use PowerShell instead.

However, there is an issue with spacing on Windows that prevented me from using PowerShell with NvChad's integrated terminal.

### Usecase
![image](https://github.com/user-attachments/assets/4b724430-8efb-4c6a-8455-9deeb12fb3bd)


I tried to fix the error, and while I found a workaround, it resulted in two shells continuously opening.
## Configuration

```lua
-- lua\options.lua
vim.o.shell = "C:\\Program Files\\PowerShell\\7\\pwsh.exe"
```
```lua
-- lua\configs\mappings\terminal.lua
map({ "n", "t" }, "<A-i>", function()
  require("nvchad.term").toggle {
    pos = "float",
    id = "floatTerm",

    float_opts = {
      relative = "editor",
      width = 0.75,
      height = 0.80,
      row = 0.050,
      col = 0.10,
      border = "double",
    },

    cmd = 'C:\\"Program Files"\\PowerShell\\7\\pwsh.exe'
}
end, { desc = "terminal toggle floating term" })
```
### Usecase
![image](https://github.com/user-attachments/assets/4bebd6f1-c959-4cb2-90d3-80aa1aee99d8)


## Solution
No solution was found to fix this new bug by modifying the NvChad configuration, so I forked the repository and located the bug in the line that was modified in the PR. This resolved the issue, and now the integrated terminals in NvChad work correctly.
```lua
-- lua\plugins\init.lua
  {
    "NvChad/ui",
    url = "https://github.com/RoboG-11/ui",
  },
```
```lua
-- lua/nvchad/term/init.lua
  if opts.cmd and opts.buf then
    cmd = { shell, "-c", format_cmd(opts.cmd) .. "; " .. shell }
  else
    cmd = { shell }
  end
```
### Usecase
![image](https://github.com/user-attachments/assets/9ea6230a-3cc1-4173-afae-9c741d5fb2cf)
