### PR TITLE
fix(mappings): theme selector in normal mode

### DIFF
--- a/lua/nvchad/themes/mappings.lua
+++ b/lua/nvchad/themes/mappings.lua
@@ -13,9 +13,9 @@ local function reload_theme(name)
   require "volt.highlights"
 end
 
-local map = function(keys, func, opts)
+local map = function(mode, keys, func, opts)
   for _, key in ipairs(keys) do
-    vim.keymap.set("i", key, func, opts)
+    vim.keymap.set(mode, key, func, opts)
   end
 end
 
@@ -40,7 +40,7 @@ local function scroll_down(n, direction)
   end
 end
 
-map({ "<C-n>", "<Down>" }, function()
+local function move_down()
   if #state.themes_shown > 0 then
     local theme = set_index(1)
     reload_theme(theme)
@@ -53,9 +53,12 @@ map({ "<C-n>", "<Down>" }, function()
       end)
     end
   end
-end, { buffer = state.input_buf })
+end
 
-map({ "<C-p>", "<Up>" }, function()
+map("i", { "<C-n>", "<Down>" }, move_down, { buffer = state.input_buf })
+map("n", { "j", "<Down>" }, move_down, { buffer = state.input_buf })
+
+local function move_up()
   if #state.themes_shown > 0 then
     local theme = set_index(-1)
     reload_theme(theme)
@@ -66,9 +69,12 @@ map({ "<C-p>", "<Up>" }, function()
       scroll_down(state.scroll_step[state.style], "up")
     end)
   end
-end, { buffer = state.input_buf })
+end
 
-map({ "<cr>" }, function()
+map("i", { "<C-p>", "<Up>" }, move_up, { buffer = state.input_buf })
+map("n", { "k", "<Up>" }, move_up, { buffer = state.input_buf })
+
+map({ "i", "n" }, { "<cr>" }, function()
   local name = state.themes_shown[state.index]
   local chadrc = dofile(vim.fn.stdpath "config" .. "/lua/chadrc.lua")
   local old_theme = chadrc.base46.theme
@@ -79,12 +85,8 @@ map({ "<cr>" }, function()
   require("volt").close()
 end, { buffer = state.input_buf })
 
-map({ "<esc>" }, function()
-  require("volt").close()
-end, { buffer = state.input_buf })
-
 -- delete text
-map({ "<C-w>" }, function()
+map("i", { "<C-w>" }, function()
   vim.api.nvim_input "<c-s-w>"
 end, { buffer = state.input_buf })
 


### PR DESCRIPTION
we can't `<esc>` go to normal mode and use `j` and `k` to preview the themes as of now, this addresses this easier navigation method :)