### PR TITLE
fix: allow chadrc to be a module and skip file writing if it doesn't exist

### DIFF
--- a/lua/nvchad/themes/mappings.lua
+++ b/lua/nvchad/themes/mappings.lua
@@ -76,7 +76,8 @@ map("n", { "k", "<Up>" }, move_up, { buffer = state.input_buf })
 
 map({ "i", "n" }, { "<cr>" }, function()
   local name = state.themes_shown[state.index]
-  local chadrc = dofile(vim.fn.stdpath "config" .. "/lua/chadrc.lua")
+  package.loaded.chadrc = nil
+  local chadrc = require "chadrc"
   local old_theme = chadrc.base46.theme
 
   old_theme = '"' .. old_theme .. '"'

--- a/lua/nvchad/utils.lua
+++ b/lua/nvchad/utils.lua
@@ -23,12 +23,14 @@ M.replace_word = function(old, new, filepath)
   filepath = filepath or vim.fn.stdpath "config" .. "/lua/" .. "chadrc.lua"
 
   local file = io.open(filepath, "r")
-  local added_pattern = string.gsub(old, "-", "%%-") -- add % before - if exists
-  local new_content = file:read("*all"):gsub(added_pattern, new)
+  if file then
+    local added_pattern = string.gsub(old, "-", "%%-") -- add % before - if exists
+    local new_content = file:read("*all"):gsub(added_pattern, new)
 
-  file = io.open(filepath, "w")
-  file:write(new_content)
-  file:close()
+    file = io.open(filepath, "w")
+    file:write(new_content)
+    file:close()
+  end
 end
 
 M.set_cleanbuf_opts = function(ft)

--- a/lua/telescope/_extensions/themes.lua
+++ b/lua/telescope/_extensions/themes.lua
@@ -63,7 +63,8 @@ local function switcher()
       ------------ save theme to chadrc on enter ----------------
       actions.select_default:replace(function()
         if action_state.get_selected_entry() then
-          local chadrc = dofile(vim.fn.stdpath "config" .. "/lua/chadrc.lua")
+          package.loaded.chadrc = nil
+          local chadrc = require "chadrc"
           local old_theme = chadrc.base46.theme
           old_theme = '"' .. old_theme .. '"'
 


### PR DESCRIPTION
Currently there is a hard requirement on `chadrc.lua` existing in `~/.config/nvim/lua/chadrc.lua`. This makes a couple small changes to allow it to be a real lua module if the user wants to use that approach. If they do set it up as a lua module and `~/.config/nvim/lua/chadrc.lua` doesn't exist, then it will skip writing updates to the file.