### PR TITLE
chore(types): make ChangedTheme fields for themes be optional

### DIFF
--- a/scripts/update-nvchad-types.lua
+++ b/scripts/update-nvchad-types.lua
@@ -39,7 +39,7 @@ local gen_themes = function()
     local theme_name = get_base_name(name)
     table.insert(contents, 9, "---| '\"" .. theme_name .. "\"'")
     table.insert(contents,
-      string.format("---@field %s ThemeTable # Changes for %s theme",
+      string.format("---@field %s? ThemeTable # Changes for %s theme",
         theme_name:match("[^%l%u_]") and '["' .. theme_name .. '"]' or theme_name, theme_name))
   end
 


### PR DESCRIPTION
This second PR is a continuation for <https://github.com/NvChad/ui/pull/354>.

This is a small improvement for the script in charge of types generation, which will make sure to set theme fields under `ChangedTheme` as optional values.