### PR TITLE
Feat: Add custom keymap capabilities to theme switcher

### DIFF
--- a/doc/nvui.txt
+++ b/doc/nvui.txt
@@ -215,6 +215,12 @@ Only those you want to change and the it'll override the defaults.
      virt_text = "󱓻 ",
      highlight = { hex = true, lspvars = true },
    },
+
+   theme_switcher = {
+     border = false,
+     style = "bordered", -- bordered, compact, flat
+     mappings = {}, -- add your own keymaps here
+   },
  }
  
 ==============================================================================

--- a/lua/nvchad/themes/api.lua
+++ b/lua/nvchad/themes/api.lua
@@ -1,0 +1,57 @@
+local M = {}
+
+local api = vim.api
+local state = require "nvchad.themes.state"
+local redraw = require("volt").redraw
+local utils = require "nvchad.themes.utils"
+
+local set_index = function(n)
+  local list = state.themes_shown
+
+  if n == 1 and state.index < #list then
+    state.index = state.index + n
+  elseif n == -1 and state.index > 1 then
+    state.index = state.index + n
+  end
+
+  state.active_theme = list[state.index]
+  return state.active_theme
+end
+
+local function scroll_down(n, direction)
+  if direction == "up" then
+    vim.cmd("normal!" .. n .. "")
+  else
+    vim.cmd("normal!" .. n .. "")
+  end
+end
+
+M.move_down = function()
+  if #state.themes_shown > 0 then
+    local theme = set_index(1)
+    utils.reload_theme(theme)
+    redraw(state.buf, "all")
+
+    if state.index + 1 > state.limit[state.style] then
+      api.nvim_buf_call(state.buf, function()
+        state.scrolled = true
+        scroll_down(state.scroll_step[state.style], "down")
+      end)
+    end
+  end
+end
+
+M.move_up = function()
+  if #state.themes_shown > 0 then
+    local theme = set_index(-1)
+    utils.reload_theme(theme)
+    redraw(state.buf, "all")
+
+    api.nvim_buf_call(state.buf, function()
+      state.scrolled = true
+      scroll_down(state.scroll_step[state.style], "up")
+    end)
+  end
+end
+
+return M

--- a/lua/nvchad/themes/init.lua
+++ b/lua/nvchad/themes/init.lua
@@ -27,7 +27,9 @@ local gen_word_pad = function()
 end
 
 M.open = function(opts)
-  opts = opts or {}
+  local theme_opts = require("nvconfig").theme_switcher
+  opts = vim.tbl_deep_extend("force", opts or {}, theme_opts)
+
   state.buf = api.nvim_create_buf(false, true)
   state.input_buf = api.nvim_create_buf(false, true)
 
@@ -37,6 +39,8 @@ M.open = function(opts)
 
   state.icons.user = opts.icon
   state.icon = state.icons.user or state.icons[style]
+
+  state.mappings = opts.mappings
 
   gen_word_pad()
 

--- a/lua/nvchad/themes/mappings.lua
+++ b/lua/nvchad/themes/mappings.lua
@@ -3,9 +3,7 @@ local autocmd = api.nvim_create_autocmd
 local state = require "nvchad.themes.state"
 local redraw = require("volt").redraw
 local utils = require "nvchad.themes.utils"
-
-local scrolled = false
-local textchanged = false
+local nvapi = require "nvchad.themes.api"
 
 local map = function(mode, keys, func, opts)
   for _, key in ipairs(keys) do
@@ -13,60 +11,11 @@ local map = function(mode, keys, func, opts)
   end
 end
 
-local set_index = function(n)
-  local list = state.themes_shown
+map("i", { "<C-n>", "<Down>" }, nvapi.move_down, { buffer = state.input_buf })
+map("n", { "j", "<Down>" }, nvapi.move_down, { buffer = state.input_buf })
 
-  if n == 1 and state.index < #list then
-    state.index = state.index + n
-  elseif n == -1 and state.index > 1 then
-    state.index = state.index + n
-  end
-
-  state.active_theme = list[state.index]
-  return state.active_theme
-end
-
-local function scroll_down(n, direction)
-  if direction == "up" then
-    vim.cmd("normal!" .. n .. "")
-  else
-    vim.cmd("normal!" .. n .. "")
-  end
-end
-
-local function move_down()
-  if #state.themes_shown > 0 then
-    local theme = set_index(1)
-    utils.reload_theme(theme)
-    redraw(state.buf, "all")
-
-    if state.index + 1 > state.limit[state.style] then
-      api.nvim_buf_call(state.buf, function()
-        scrolled = true
-        scroll_down(state.scroll_step[state.style], "down")
-      end)
-    end
-  end
-end
-
-map("i", { "<C-n>", "<Down>" }, move_down, { buffer = state.input_buf })
-map("n", { "j", "<Down>" }, move_down, { buffer = state.input_buf })
-
-local function move_up()
-  if #state.themes_shown > 0 then
-    local theme = set_index(-1)
-    utils.reload_theme(theme)
-    redraw(state.buf, "all")
-
-    api.nvim_buf_call(state.buf, function()
-      scrolled = true
-      scroll_down(state.scroll_step[state.style], "up")
-    end)
-  end
-end
-
-map("i", { "<C-p>", "<Up>" }, move_up, { buffer = state.input_buf })
-map("n", { "k", "<Up>" }, move_up, { buffer = state.input_buf })
+map("i", { "<C-p>", "<Up>" }, nvapi.move_up, { buffer = state.input_buf })
+map("n", { "k", "<Up>" }, nvapi.move_up, { buffer = state.input_buf })
 
 map({ "i", "n" }, { "<cr>" }, function()
   state.confirmed = true
@@ -85,6 +34,15 @@ map("i", { "<C-w>" }, function()
   vim.api.nvim_input "<c-s-w>"
 end, { buffer = state.input_buf })
 
+if state.mappings then
+  for mode, mappings_list in pairs(state.mappings) do
+    for _, mapping in ipairs(mappings_list) do
+      local keys, desc, func = mapping[1], mapping[2], mapping[3]
+      map(mode, { keys }, func, { buffer = state.input_buf, desc = desc })
+    end
+  end
+end
+
 ---------------------- autocmds ----------------------
 
 api.nvim_win_set_cursor(state.input_win, { 1, 6 })
@@ -93,7 +51,7 @@ autocmd("TextChangedI", {
   buffer = state.input_buf,
 
   callback = function()
-    if scrolled then
+    if state.scrolled then
       api.nvim_buf_call(state.buf, function()
         vim.cmd "normal! gg"
       end)
@@ -116,12 +74,12 @@ autocmd("TextChangedI", {
 
     api.nvim_set_option_value("modifiable", false, { buf = state.buf })
 
-    if textchanged and #state.themes_shown > 0 then
+    if state.textchanged and #state.themes_shown > 0 then
       utils.reload_theme(state.themes_shown[1])
     end
 
     redraw(state.buf, "all")
-    scrolled = false
-    textchanged = true
+    state.scrolled = false
+    state.textchanged = true
   end,
 })

--- a/lua/nvchad/themes/state.lua
+++ b/lua/nvchad/themes/state.lua
@@ -8,6 +8,8 @@ local M = {
     bordered = 7,
   },
 
+  mappings = {},
+
   start_row = 1,
   xpad = 1,
   word_gap = 5,
@@ -40,6 +42,9 @@ local M = {
     flat = 3,
     bordered = 2,
   },
+
+  scrolled = false,
+  textchanged = false,
 }
 
 return M

--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -110,6 +110,12 @@ local options = {
     virt_text = "󱓻 ",
     highlight = { hex = true, lspvars = true },
   },
+
+  theme_switcher = {
+    border = false,
+    style = "bordered", -- bordered, compact, flat
+    mappings = {}, -- add your own keymaps here
+  },
 }
 
 local status, chadrc = pcall(require, "chadrc")

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -9,6 +9,7 @@
 ---@field mason? MasonConfig
 ---@field colorify? ColorifyConfig
 ---@field nvdash? NvDashConfig
+---@field theme_switcher? ThemeSwitcherConfig
 
 ---@class Base46Config
 --- List of highlights group to add.
@@ -67,7 +68,7 @@
 --- nvim-cmp style
 ---@field style? '"default"'|'"flat_light"'|'"flat_dark"'|'"atom"'|'"atom_colored"'
 --- Only has effects when the style is `default`
---- @field icons_left? boolean 
+--- @field icons_left? boolean
 --- places lspkind icons to the left, only for non-atom styles
 --- @field format_colors? NvCmpFormatColors
 
@@ -175,3 +176,15 @@
 ---@class NvCmpFormatColors
 ---@field icon? string # icon to use for color swatches
 ---@field tailwind? boolean # show colors from tailwind/css/astro lsp in menu
+
+---@class ThemeSwitcherConfig
+---@field mappings? ThemeSwitcherMappings
+---@field style? "bordered" | "compact" | "flat"
+---@field icon? string
+---@field border? boolean
+
+---@class ThemeSwitcherMappings
+--- Mappings for insert mode
+---@field i? table<string, {string, string, function}> # A table where the first value is a keybind, the second value is a description, and the third value is a function to execute
+--- Mappings for normal mode
+---@field n? table<string, {string, string, function}> # A table where the first value is a keybind, the second value is a description, and the third value is a function to execute


### PR DESCRIPTION
In order to enable customizing the keymaps for the new theme switcher, this commit extracts most of the navigation functions out of mappings.lua into a new api.lua. This allows the navigation functions to be publicly exposed as a module which can then be used when setting up custom keymaps.

Additionally, this commit adds the ability to customize the new theme switcher via Chadrc with a new `theme_switcher` field. This new field on the Chadrc configuration allows adding key mappings for both insert and normal mode.