### PR TITLE
Allow passing termopen_opts to terminal creation functions

### DIFF
--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -102,7 +102,7 @@ local function create(opts)
   save_term_info(opts.buf, opts)
 
   if not buf_exists then
-    vim.fn.termopen(cmd, opts)
+    vim.fn.termopen(cmd, opts.termopen_opts)
   end
 
   vim.g.nvhterm = opts.pos == "sp"

--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -102,7 +102,7 @@ local function create(opts)
   save_term_info(opts.buf, opts)
 
   if not buf_exists then
-    vim.fn.termopen(cmd)
+    vim.fn.termopen(cmd, opts)
   end
 
   vim.g.nvhterm = opts.pos == "sp"


### PR DESCRIPTION
This allows adding environment variables to the terminal and overriding other `jobstart-options`

For example when using the `nvchad.term` module directly
```lua
require("nvchad.term").toggle {
  pos = "float",
  id = "floatTerm",
  termopen_opts = {
    env = { TERM = "tmux-256color" }
  }
}
```