### PR TITLE
fix: prevent nil icon due to 0 index in math

### DIFF
--- a/lua/nvchad/stl/utils.lua
+++ b/lua/nvchad/stl/utils.lua
@@ -165,7 +165,8 @@ M.autocmds = function()
       local progress = ""
 
       if data.percentage then
-        local icon = spinners[math.floor(data.percentage / 10)]
+        local idx = math.max(1, math.floor(data.percentage / 10))
+        local icon = spinners[idx]
         progress = icon .. " " .. data.percentage .. "%% "
       end
 


### PR DESCRIPTION
Wasn't quite fixed by [04ed330](https://github.com/NvChad/ui/commit/04ed330c30b1a34641b638b4f94a6bb08f158c74)

See #371