### PR TITLE
Add BladeNav icon

### DIFF
--- a/lua/nvchad/icons/lspkind.lua
+++ b/lua/nvchad/icons/lspkind.lua
@@ -40,4 +40,5 @@ return {
   Copilot = "",
   Codeium = "",
   TabNine = "",
+  BladeNav = "",
 }


### PR DESCRIPTION
This PR add the icon for [blade-nav](https://github.com/RicardoRamirezR/blade-nav.nvim)

blade-nav is a plugin that provide completion and easier file navigation for [Laravel](https://laravel.com)

