### PR TITLE
Add a Filetype to NvTerm Buffers

### DIFF
--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -62,6 +62,7 @@ M.display = function(opts)
   opts.win = win
 
   vim.bo[opts.buf].buflisted = false
+  vim.bo[opts.buf].ft = "NvTerm_"..opts.pos
   vim.cmd "startinsert"
 
   -- resize non floating wins initially + or only when they're toggleable


### PR DESCRIPTION
As the description says, this adds a Filetype to NvTerm Buffers. 
This Filetype is comprised of the string "Nvterm_", followed by the type of the Term buffer, e.g. "NvTerm_float"