### PR TITLE
fix: broken nvchad.term pos option bo sp and bo vsp

### DIFF
--- a/lua/nvchad/term/init.lua
+++ b/lua/nvchad/term/init.lua
@@ -62,7 +62,7 @@ M.display = function(opts)
   opts.win = win
 
   vim.bo[opts.buf].buflisted = false
-  vim.bo[opts.buf].ft = "NvTerm_"..opts.pos
+  vim.bo[opts.buf].ft = "NvTerm_"..opts.pos:gsub(" ", "")
   vim.cmd "startinsert"
 
   -- resize non floating wins initially + or only when they're toggleable


### PR DESCRIPTION
Fixes broken `nvchad.term` option `pos` when the value is set to botright, which has spaces like `bo sp` and `bo vsp`.

Botright options are added at #294, and broken at #389.

To reproduce: 

```lua
require "nvchad.term".toggle { pos = "bo sp" }
```