### PR TITLE
feat: Allow mason.nvim to skip detected pkgs during MasonInstallAll

### DIFF
--- a/doc/nvui.txt
+++ b/doc/nvui.txt
@@ -209,7 +209,7 @@ Only those you want to change and the it'll override the defaults.
      excluded_groups = { "terminal (t)", "autopairs", "Nvim", "Opens" }, -- can add group name or with mode
    },
 
-   mason = { pkgs = {} },
+   mason = { pkgs = {}, skip = {} },
 
    colorify = {
      enabled = true,

--- a/lua/nvchad/mason/init.lua
+++ b/lua/nvchad/mason/init.lua
@@ -31,11 +31,7 @@ M.get_pkgs = function()
 
   -- rm duplicates
   for _, v in pairs(tools) do
-    if
-      not vim.tbl_contains(pkgs, masonames[v])
-      and not vim.tbl_contains(skipped, masonames[v])
-      and not vim.tbl_contains(skipped, v)
-    then
+    if not vim.tbl_contains(pkgs, masonames[v]) and not vim.tbl_contains(skipped, masonames[v]) then
       table.insert(pkgs, masonames[v])
     end
   end

--- a/lua/nvchad/mason/init.lua
+++ b/lua/nvchad/mason/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 local masonames = require "nvchad.mason.names"
 local pkgs = require("nvconfig").mason.pkgs
+local skipped = require("nvconfig").mason.skip
 
 M.get_pkgs = function()
   local tools = {}
@@ -30,7 +31,11 @@ M.get_pkgs = function()
 
   -- rm duplicates
   for _, v in pairs(tools) do
-    if not (vim.tbl_contains(pkgs, masonames[v])) then
+    if
+      not vim.tbl_contains(pkgs, masonames[v])
+      and not vim.tbl_contains(skipped, masonames[v])
+      and not vim.tbl_contains(skipped, v)
+    then
       table.insert(pkgs, masonames[v])
     end
   end

--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -102,7 +102,7 @@ local options = {
     excluded_groups = { "terminal (t)", "autopairs", "Nvim", "Opens" }, -- can add group name or with mode
   },
 
-  mason = { pkgs = {} },
+  mason = { pkgs = {}, skip = {} },
 
   colorify = {
     enabled = true,


### PR DESCRIPTION
Context:  I want `clangd` lsp-configured but already have it in `$PATH`, so do not want Mason installing an additional copy.

Problem: NvChad detects my `clangd` (and other lsp's) as a configured lsp, then automatically batch installs it during `:MasonInstallAll`.

This PR adds the ability to add a "skip" entry in the `chadrc.lua` file.  Any mason packages listed here will be ignored/skipped.

Video shows `clangd` being prevent from being installed (Great!).  For demo purposes, I also prevented Mason from installing `html`/`html-lsp` and `cssls`/`css-lsp`:

https://github.com/user-attachments/assets/7177e0bd-eb0c-4150-a889-633555de19e8
