### PR TITLE
fix cmp item menu when not using atom style

### DIFF
--- a/lua/nvchad/cmp/format.lua
+++ b/lua/nvchad/cmp/format.lua
@@ -1,9 +1,9 @@
 local M = {}
 local api = vim.api
 local cmp_ui = require("nvconfig").ui.cmp
-local colors_icon = cmp_ui.format_colors.icon .. " "
+local icon = cmp_ui.format_colors.icon .. " "
 
-M.tailwind = function(entry, item)
+M.tailwind = function(entry, item, kind_txt)
   local entryItem = entry:get_completion_item()
   local color = entryItem.documentation
 
@@ -14,7 +14,7 @@ M.tailwind = function(entry, item)
       api.nvim_set_hl(0, hl, { fg = color })
     end
 
-    item.kind = cmp_ui.icons_left and colors_icon or " " .. colors_icon
+    item.kind = ((cmp_ui.icons_left and icon) or (" " .. icon)) .. kind_txt
     item.kind_hl_group = hl
     item.menu_hl_group = hl
   end

--- a/lua/nvchad/cmp/init.lua
+++ b/lua/nvchad/cmp/init.lua
@@ -11,16 +11,16 @@ local M = {
       local icons = require "nvchad.icons.lspkind"
       local icon = icons[item.kind] or ""
 
-      if atom_styled or cmp_ui.icons_left then
+      if atom_styled then
         item.menu = cmp_ui.lspkind_text and item.kind or ""
         item.menu_hl_group = "LineNr"
+        item.kind = " " .. icon
+      elseif cmp_ui.icons_left then
+        item.menu = cmp_ui.lspkind_text and item.kind or ""
+        item.menu_hl_group = "CmpItemKind" .. (item.kind or "")
         item.kind = icon
       else
         item.kind = cmp_ui.lspkind_text and icon .. " " .. item.kind or ""
-      end
-
-      if not cmp_ui.icons_left then
-        item.kind = " " .. item.kind
       end
 
       if cmp_ui.format_colors.tailwind then

--- a/lua/nvchad/cmp/init.lua
+++ b/lua/nvchad/cmp/init.lua
@@ -9,11 +9,15 @@ local M = {
   formatting = {
     format = function(entry, item)
       local icons = require "nvchad.icons.lspkind"
+      local icon = icons[item.kind] or ""
 
-      item.abbr = item.abbr .. " "
-      item.menu = cmp_ui.lspkind_text and item.kind or ""
-      item.menu_hl_group = atom_styled and "LineNr" or "CmpItemKind" .. (item.kind or "")
-      item.kind = (icons[item.kind] or "") .. " "
+      if atom_styled then
+        item.menu = cmp_ui.lspkind_text and item.kind or ""
+        item.menu_hl_group = "LineNr"
+        item.kind = icon
+      else
+        item.kind = cmp_ui.lspkind_text and icon .. " " .. item.kind or ""
+      end
 
       if not cmp_ui.icons_left then
         item.kind = " " .. item.kind

--- a/lua/nvchad/cmp/init.lua
+++ b/lua/nvchad/cmp/init.lua
@@ -1,6 +1,6 @@
 local cmp_ui = require("nvconfig").ui.cmp
 local cmp_style = cmp_ui.style
-local format_kk = require "nvchad.cmp.format"
+local format_color = require "nvchad.cmp.format"
 
 local atom_styled = cmp_style == "atom" or cmp_style == "atom_colored"
 local fields = (atom_styled or cmp_ui.icons_left) and { "kind", "abbr", "menu" } or { "abbr", "kind", "menu" }
@@ -10,21 +10,23 @@ local M = {
     format = function(entry, item)
       local icons = require "nvchad.icons.lspkind"
       local icon = icons[item.kind] or ""
+      local kind = item.kind or ""
 
       if atom_styled then
-        item.menu = cmp_ui.lspkind_text and item.kind or ""
+        item.menu = kind
         item.menu_hl_group = "LineNr"
-        item.kind = " " .. icon
+        item.kind = " " .. icon .. " "
       elseif cmp_ui.icons_left then
-        item.menu = cmp_ui.lspkind_text and item.kind or ""
-        item.menu_hl_group = "CmpItemKind" .. (item.kind or "")
+        item.menu = kind
+        item.menu_hl_group = "CmpItemKind" .. kind
         item.kind = icon
       else
-        item.kind = cmp_ui.lspkind_text and icon .. " " .. item.kind or ""
+        item.kind = " " .. icon .. " " .. kind
+        item.menu_hl_group = "comment"
       end
 
-      if cmp_ui.format_colors.tailwind then
-        format_kk.tailwind(entry, item)
+      if kind == "Color" and cmp_ui.format_colors.tailwind then
+        format_color.tailwind(entry, item, (not (atom_styled or cmp_ui.icons_left) and kind) or "")
       end
 
       return item

--- a/lua/nvchad/cmp/init.lua
+++ b/lua/nvchad/cmp/init.lua
@@ -11,7 +11,7 @@ local M = {
       local icons = require "nvchad.icons.lspkind"
       local icon = icons[item.kind] or ""
 
-      if atom_styled then
+      if atom_styled or cmp_ui.icons_left then
         item.menu = cmp_ui.lspkind_text and item.kind or ""
         item.menu_hl_group = "LineNr"
         item.kind = icon

--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -13,7 +13,6 @@ local options = {
   ui = {
     cmp = {
       icons_left = false, -- only for non-atom styles!
-      lspkind_text = true,
       style = "default", -- default/flat_light/flat_dark/atom/atom_colored
       format_colors = {
         tailwind = false, -- will work for css lsp too

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -63,7 +63,6 @@
 --- Whether to add colors to icons in nvim-cmp popup menu
 ---@field icons? boolean
 --- Whether to also have the lsp kind highlighted with the icons as well or not
----@field lspkind_text? boolean
 --- nvim-cmp style
 ---@field style? '"default"'|'"flat_light"'|'"flat_dark"'|'"atom"'|'"atom_colored"'
 --- Only has effects when the style is `default`


### PR DESCRIPTION
Item menu is overridden when not using atom styles. This prevents nvim-cmp from showing imports and source.

Updated config so no changes are made to `item.menu` when not using atom styles.  

[Fix](https://github.com/NvChad/ui/issues/393)