### PR TITLE
update install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ In your plugins file
 
  {
    "nvchad/ui",
-    config = function()
-      require "nvchad" 
-    end
+   config = function()
+     require "nvchad" 
+   end
  },
 
  {
@@ -26,6 +26,14 @@ In your plugins file
       require("base46").load_all_highlights()
     end,
  },
+
+ {
+    "nvim-tree/nvim-web-devicons",
+    opts = function()
+      dofile(vim.g.base46_cache .. "devicons")
+      return { override = require "nvchad.icons.devicons" }
+    end,
+  },
 
  "nvchad/volt", -- optional, needed for theme switcher
  -- or just use Telescope themes


### PR DESCRIPTION
add nvim-web-devicons to plugin list in readme

[tabufline](https://github.com/NvChad/ui/blob/c59c5fc078cc22a28604e154552c41705359145b/lua/nvchad/tabufline/utils.lua#L55) and [stl](https://github.com/NvChad/ui/blob/c59c5fc078cc22a28604e154552c41705359145b/lua/nvchad/stl/utils.lua#L89) depend on `nvim-web-devicons`