### PR TITLE
fix(tabufline): add separator to adapt NvimTreeWinSeparator hl

### DIFF
--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -36,7 +36,7 @@ vim.cmd "function! TbToggleTabs(a,b,c,d) \n let g:TbTabsToggled = !g:TbTabsToggl
 local function getNvimTreeWidth()
   for _, win in pairs(api.nvim_tabpage_list_wins(0)) do
     if vim.bo[api.nvim_win_get_buf(win)].ft == "NvimTree" then
-      return api.nvim_win_get_width(win) + 1
+      return api.nvim_win_get_width(win)
     end
   end
   return 0
@@ -59,7 +59,10 @@ local function available_space()
 end
 
 M.treeOffset = function()
-  return "%#NvimTreeNormal#" .. strep(" ", getNvimTreeWidth())
+  local tree_width = getNvimTreeWidth()
+  local spaces = "%#NvimTreeNormal#" .. strep(" ", tree_width)
+  local separator = tree_width > 0 and "%#NvimTreeWinSeparator#" .. "│" or ""
+  return spaces .. separator
 end
 
 M.buffers = function()

--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -59,10 +59,8 @@ local function available_space()
 end
 
 M.treeOffset = function()
-  local tree_width = getNvimTreeWidth()
-  local spaces = "%#NvimTreeNormal#" .. strep(" ", tree_width)
-  local separator = tree_width > 0 and "%#NvimTreeWinSeparator#" .. "│" or ""
-  return spaces .. separator
+  local w = getNvimTreeWidth()
+  return w == 0 and "" or "%#NvimTreeNormal#" .. strep(" ", w) .. "%#NvimTreeWinSeparator#" .. "│"
 end
 
 M.buffers = function()


### PR DESCRIPTION
This change add a separator character to fit the situation when overriding `NvimTreeWinSeparator` highlight.

The original apperance with nvimtree separator would be like:
![屏幕截图 2024-12-30 110602](https://github.com/user-attachments/assets/32fcc63a-2e1e-4867-823e-b5a9b35d7abe)
and the fixed one should be like this:
![屏幕截图 2024-12-30 112019](https://github.com/user-attachments/assets/b2293693-bb0e-4e56-a043-7042900710c9)
also, this change will change nothing for the original configuration
![屏幕截图 2024-12-30 114018](https://github.com/user-attachments/assets/a2bf56b5-a150-45e9-bf97-3c5c101c05e8)
