### PR TITLE
fix(renamer): force close on esc

### DIFF
--- a/lua/nvchad/lsp/renamer.lua
+++ b/lua/nvchad/lsp/renamer.lua
@@ -17,7 +17,7 @@ return function()
   vim.fn.prompt_setprompt(buf, "")
   vim.api.nvim_input "A"
 
-  vim.keymap.set({ "i", "n" }, "<Esc>", "<cmd>q<CR>", { buffer = buf })
+  vim.keymap.set({ "i", "n" }, "<Esc>", "<cmd>q!<CR>", { buffer = buf })
 
   vim.fn.prompt_setcallback(buf, function(text)
     local newName = vim.trim(text)


### PR DESCRIPTION
# Problem
There are leftover buffer(s) when I cancel renamer action.

https://github.com/user-attachments/assets/1b185fcb-86d1-46db-acf8-8efbb53ca705

# Description
This PR fixes the problem above by force quitting when pressing `<Esc>`.
result:

https://github.com/user-attachments/assets/652b8dec-e3f5-4507-8bd2-da5e747b68dd

