### PR TITLE
Fix spinner progress

### DIFF
--- a/lua/nvchad/stl/utils.lua
+++ b/lua/nvchad/stl/utils.lua
@@ -155,7 +155,7 @@ M.separators = {
 
 M.state = { lsp_msg = "" }
 
-local spinners = { "", "", "", "󰪞", "󰪟", "󰪠", "󰪢", "󰪣", "󰪤", "󰪥" }
+local spinners = { "", "󰪞", "󰪟", "󰪠", "󰪡", "󰪢", "󰪣", "󰪤", "󰪥", "" }
 
 M.autocmds = function()
   vim.api.nvim_create_autocmd("LspProgress", {

--- a/lua/nvchad/stl/utils.lua
+++ b/lua/nvchad/stl/utils.lua
@@ -159,7 +159,7 @@ local spinners = { "", "", "", "󰪞", "󰪟", "󰪠", "󰪢", "󰪣", 
 
 M.autocmds = function()
   vim.api.nvim_create_autocmd("LspProgress", {
-    pattern = { "begin", "end" },
+    pattern = { "*" },
     callback = function(args)
       local data = args.data.params.value
       local progress = ""


### PR DESCRIPTION
From what I've noticed only using "start" and "end" pattern won't update LspProgress to the spinner, which make it stopped after the first redraw.
Changing it to "*" fixed the problem.

Also the spinners icons are not matching with the percentage visually so I also changed that