### PR TITLE
fix(stl): lite loading messages

### DIFF
--- a/lua/nvchad/stl/utils.lua
+++ b/lua/nvchad/stl/utils.lua
@@ -171,7 +171,7 @@ M.autocmds = function()
       end
 
       local loaded_count = data.message and string.match(data.message, "^(%d+/%d+)") or ""
-      local str = progress .. (loaded_count or "") .. " " .. (data.title or "")
+      local str = progress .. (data.title or "") .. " " .. (loaded_count or "")
       M.state.lsp_msg = data.kind == "end" and "" or str
       vim.cmd.redrawstatus()
     end,

--- a/lua/nvchad/stl/utils.lua
+++ b/lua/nvchad/stl/utils.lua
@@ -170,7 +170,8 @@ M.autocmds = function()
         progress = icon .. " " .. data.percentage .. "%% "
       end
 
-      local str = progress .. (data.message or "") .. " " .. (data.title or "")
+      local loaded_count = data.message and string.match(data.message, "^(%d+/%d+)") or ""
+      local str = progress .. (loaded_count or "") .. " " .. (data.title or "")
       M.state.lsp_msg = data.kind == "end" and "" or str
       vim.cmd.redrawstatus()
     end,

--- a/lua/nvchad/stl/utils.lua
+++ b/lua/nvchad/stl/utils.lua
@@ -159,7 +159,7 @@ local spinners = { "", "󰪞", "󰪟", "󰪠", "󰪡", "󰪢", "󰪣", "󰪤"
 
 M.autocmds = function()
   vim.api.nvim_create_autocmd("LspProgress", {
-    pattern = { "*" },
+    pattern = { "begin", "report", "end" },
     callback = function(args)
       local data = args.data.params.value
       local progress = ""


### PR DESCRIPTION
This change replaced verbose lsp loading massages with the loaded count only, cause some lsp server such as rust analyzer has a very long progress msg body
Before:
![2025-01-08 110324](https://github.com/user-attachments/assets/ff86c212-4dde-4f9f-9361-7893a5033c1f)
After:
![image](https://github.com/user-attachments/assets/4546db7f-e79d-4c61-837e-6624991e449f)
