### PR TITLE
feat(tabufline): prompt icons for hiden tabs

### DIFF
--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -18,18 +18,37 @@ local M = {}
 vim.cmd [[
   function! TbGoToBuf(bufnr,b,c,d)
     call luaeval('require("nvchad.tabufline").goto_buf(_A)', a:bufnr)
-  endfunction]]
+  endfunction ]]
 
 vim.cmd [[
   function! TbKillBuf(bufnr,b,c,d) 
     call luaeval('require("nvchad.tabufline").close_buffer(_A)', a:bufnr)
-  endfunction]]
+  endfunction ]]
 
-vim.cmd "function! TbNewTab(a,b,c,d) \n tabnew \n endfunction"
-vim.cmd "function! TbGotoTab(tabnr,b,c,d) \n execute a:tabnr ..'tabnext' \n endfunction"
-vim.cmd "function! TbCloseAllBufs(a,b,c,d) \n lua require('nvchad.tabufline').closeAllBufs() \n endfunction"
-vim.cmd "function! TbToggle_theme(a,b,c,d) \n lua require('base46').toggle_theme() \n endfunction"
-vim.cmd "function! TbToggleTabs(a,b,c,d) \n let g:TbTabsToggled = !g:TbTabsToggled | redrawtabline \n endfunction"
+vim.cmd [[
+  function! TbNewTab(a,b,c,d)
+    tabnew
+  endfunction ]]
+
+vim.cmd [[
+  function! TbGotoTab(tabnr,b,c,d)
+    execute a:tabnr ..'tabnext'
+  endfunction ]]
+
+vim.cmd [[
+  function! TbCloseAllBufs(a,b,c,d)
+    lua require('nvchad.tabufline').closeAllBufs()
+  endfunction ]]
+
+vim.cmd [[
+  function! TbToggle_theme(a,b,c,d)
+    lua require('base46').toggle_theme()
+  endfunction ]]
+
+vim.cmd [[
+  function! TbToggleTabs(a,b,c,d)
+    let g:TbTabsToggled = !g:TbTabsToggled | redrawtabline
+  endfunction ]]
 
 ---------------------------------- functions -------------------------------------------
 

--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -12,7 +12,6 @@ local cur_buf = api.nvim_get_current_buf
 local opts = require("nvconfig").ui.tabufline
 
 local M = {}
-g.toggle_theme_icon = "   "
 
 ------------------------------- btn actions functions -----------------------------------
 
@@ -104,10 +103,18 @@ M.tabs = function()
   return ""
 end
 
+g.toggle_theme_icon = "   "
+
+M.btn_toggle_theme = function()
+  return btn(g.toggle_theme_icon, "ThemeToggleBtn", "Toggle_theme")
+end
+
+M.btn_close_all = function()
+  return btn(" 󰅖 ", "CloseAllBufsBtn", "CloseAllBufs")
+end
+
 M.btns = function()
-  local toggle_theme = btn(g.toggle_theme_icon, "ThemeToggleBtn", "Toggle_theme")
-  local closeAllBufs = btn(" 󰅖 ", "CloseAllBufsBtn", "CloseAllBufs")
-  return toggle_theme .. closeAllBufs
+  return M.btn_toggle_theme() .. M.btn_close_all()
 end
 
 return function()

--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -75,14 +75,14 @@ local function available_space()
 end
 
 local function render_buffers(start, max)
-  local bufs_str = ""
+  local bufs_str = g.tbl_bufs_start > 1 and "%#NvimTreeNormal#" or ""
   for i, buf_id in ipairs(vim.t.bufs) do
     if i >= start and i < (start + max) then
       bufs_str = bufs_str .. style_buf(buf_id, i, opts.bufwidth)
     end
   end
-  -- buffers + empty space
-  return bufs_str .. txt("%=", "Fill")
+  local right_icon = g.tbl_bufs_start + max - 1 < #vim.t.bufs and "%#NvimTreeNormal#" or ""
+  return bufs_str .. right_icon .. txt("%=", "Fill")
 end
 
 ------------------------------------- modules -----------------------------------------

--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -83,12 +83,11 @@ M.buffers = function()
       -- on the left
       if i < g.tbl_bufs_start then
         g.tbl_bufs_start = i
-        break
       -- on the right
       elseif i >= g.tbl_bufs_start + max_tabs then
         g.tbl_bufs_start = i - max_tabs + 1
-        break
       end
+      break
     end
   end
 

--- a/lua/nvchad/tabufline/modules.lua
+++ b/lua/nvchad/tabufline/modules.lua
@@ -26,6 +26,18 @@ vim.cmd [[
   endfunction ]]
 
 vim.cmd [[
+  function! TbGoLeft(a,b,c,d)
+    let g:tbl_bufs_start = g:tbl_bufs_start - 1
+    lua require('nvchad.tabufline.modules')()
+  endfunction ]]
+
+vim.cmd [[
+  function! TbGoRight(a,b,c,d)
+    let g:tbl_bufs_start = g:tbl_bufs_start + 1
+    lua require('nvchad.tabufline.modules')()
+  endfunction ]]
+
+vim.cmd [[
   function! TbNewTab(a,b,c,d)
     tabnew
   endfunction ]]
@@ -75,14 +87,21 @@ local function available_space()
 end
 
 local function render_buffers(start, max)
-  local bufs_str = g.tbl_bufs_start > 1 and "%#NvimTreeNormal#" or ""
+  -- early return to prevent unnecessary prompt icons
+  if #vim.t.bufs == 0 then
+    return txt("%=", "Fill")
+  end
+
+  local bufs_str = start > 1 and btn("", "Normal", "GoLeft") or ""
   for i, buf_id in ipairs(vim.t.bufs) do
     if i >= start and i < (start + max) then
       bufs_str = bufs_str .. style_buf(buf_id, i, opts.bufwidth)
     end
   end
-  local right_icon = g.tbl_bufs_start + max - 1 < #vim.t.bufs and "%#NvimTreeNormal#" or ""
-  return bufs_str .. right_icon .. txt("%=", "Fill")
+  if start + max - 1 < #vim.t.bufs then
+    bufs_str = bufs_str .. btn("", "Normal", "GoRight")
+  end
+  return bufs_str .. txt("%=", "Fill")
 end
 
 ------------------------------------- modules -----------------------------------------

--- a/lua/nvchad/tabufline/utils.lua
+++ b/lua/nvchad/tabufline/utils.lua
@@ -41,15 +41,15 @@ local function gen_unique_name(oldname, index)
   end
 end
 
-M.style_buf = function(nr, i, w)
+M.style_buf = function(bufid, bufindex, bufwidth)
   -- add fileicon + name
   local icon = "󰈚 "
-  local is_curbuf = cur_buf() == nr
+  local is_curbuf = cur_buf() == bufid
   local tbHlName = "BufO" .. (is_curbuf and "n" or "ff")
   local icon_hl = new_hl("DevIconDefault", tbHlName)
 
-  local name = filename(buf_name(nr))
-  name = gen_unique_name(name, i) or name
+  local name = filename(buf_name(bufid))
+  name = gen_unique_name(name, bufindex) or name
   name = (name == "" or not name) and " No Name " or name
 
   if name ~= " No Name " then
@@ -61,22 +61,25 @@ M.style_buf = function(nr, i, w)
     end
   end
 
-  -- padding around bufname; 15= maxnamelen + 2 icon & space + 2 close icon
-  local pad = math.floor((w - #name - 5) / 2)
-  pad = pad <= 0 and 1 or pad
+  -- padding 6 = left_icon 3 + right_icon 3
+  local maxname_len = bufwidth - 6
 
-  local maxname_len = 15
+  if #name > maxname_len then
+    name = string.sub(name, 1, maxname_len - 1) .. "…"
+  end
 
-  name = string.sub(name, 1, 13) .. (#name > maxname_len and ".." or "")
+  local lpad = math.floor((maxname_len - #name) / 2)
+  local rpad = maxname_len - #name - lpad
+
   name = M.txt(name, tbHlName)
 
-  name = strep(" ", pad - 1) .. (icon_hl .. icon .. name) .. strep(" ", pad - 1)
+  name = strep(" ", lpad) .. (icon_hl .. icon .. name) .. strep(" ", rpad)
 
-  local close_btn = btn(" 󰅖 ", nil, "KillBuf", nr)
-  name = btn(name, nil, "GoToBuf", nr)
+  local close_btn = btn(" 󰅖 ", nil, "KillBuf", bufid)
+  name = btn(name, nil, "GoToBuf", bufid)
 
   -- modified bufs icon or close icon
-  local mod = get_opt("mod", { buf = nr })
+  local mod = get_opt("mod", { buf = bufid })
   local cur_mod = get_opt("mod", { buf = 0 })
 
   -- color close btn for focused / hidden  buffers

--- a/lua/nvchad/tabufline/utils.lua
+++ b/lua/nvchad/tabufline/utils.lua
@@ -84,9 +84,9 @@ M.style_buf = function(bufid, bufindex, bufwidth)
 
   -- color close btn for focused / hidden  buffers
   if is_curbuf then
-    close_btn = cur_mod and txt("  ", "BufOnModified") or txt(close_btn, "BufOnClose")
+    close_btn = cur_mod and txt(" ● ", "BufOnModified") or txt(close_btn, "BufOnClose")
   else
-    close_btn = mod and txt("  ", "BufOffModified") or txt(close_btn, "BufOffClose")
+    close_btn = mod and txt(" ● ", "BufOffModified") or txt(close_btn, "BufOffClose")
   end
 
   name = txt(name .. close_btn, "BufO" .. (is_curbuf and "n" or "ff"))

--- a/lua/nvchad/tabufline/utils.lua
+++ b/lua/nvchad/tabufline/utils.lua
@@ -61,8 +61,8 @@ M.style_buf = function(bufid, bufindex, bufwidth)
     end
   end
 
-  -- padding 6 = left_icon 3 + right_icon 3
-  local maxname_len = bufwidth - 6
+  -- padding 5 = left_icon 3 + right_icon 2
+  local maxname_len = bufwidth - 5
 
   if #name > maxname_len then
     name = string.sub(name, 1, maxname_len - 1) .. "…"
@@ -72,10 +72,9 @@ M.style_buf = function(bufid, bufindex, bufwidth)
   local rpad = maxname_len - #name - lpad
 
   name = M.txt(name, tbHlName)
-
   name = strep(" ", lpad) .. (icon_hl .. icon .. name) .. strep(" ", rpad)
 
-  local close_btn = btn(" 󰅖 ", nil, "KillBuf", bufid)
+  local close_btn = btn(" ", nil, "KillBuf", bufid)
   name = btn(name, nil, "GoToBuf", bufid)
 
   -- modified bufs icon or close icon
@@ -84,9 +83,9 @@ M.style_buf = function(bufid, bufindex, bufwidth)
 
   -- color close btn for focused / hidden  buffers
   if is_curbuf then
-    close_btn = cur_mod and txt(" ● ", "BufOnModified") or txt(close_btn, "BufOnClose")
+    close_btn = cur_mod and txt(" ", "BufOnModified") or txt(close_btn, "BufOnClose")
   else
-    close_btn = mod and txt(" ● ", "BufOffModified") or txt(close_btn, "BufOffClose")
+    close_btn = mod and txt(" ", "BufOffModified") or txt(close_btn, "BufOffClose")
   end
 
   name = txt(name .. close_btn, "BufO" .. (is_curbuf and "n" or "ff"))


### PR DESCRIPTION
This feature could add a clickable icon to side of tbl when there're any hiden tab buffers. and if you click them, the tab buffer ranges will move in that direction.

![image](https://github.com/user-attachments/assets/bee58a92-091f-40e9-90ac-389238d0704f)

![image](https://github.com/user-attachments/assets/1db42c1e-2b95-41e3-80eb-f4293bb26b0a)

https://github.com/user-attachments/assets/d2e88e65-03b7-494d-a74b-c45306d7cec4

Since this feature is base on the latest pr #425, so there're some commits from it