### PR TITLE
Guard clause for callback in autocmds function in stl/utils.lua

### DIFF
--- a/lua/nvchad/stl/utils.lua
+++ b/lua/nvchad/stl/utils.lua
@@ -161,6 +161,11 @@ M.autocmds = function()
   vim.api.nvim_create_autocmd("LspProgress", {
     pattern = { "begin", "report", "end" },
     callback = function(args)
+      -- Ensure params exists before accessing its fields
+      if not args.data or not args.data.params then
+        return
+      end
+
       local data = args.data.params.value
       local progress = ""
 


### PR DESCRIPTION
Was running into this error:

```
Error detected while processing LspProgress Autocommands for "begin":                                                                                                
Error executing lua callback: ...nderg/.local/share/nvim/lazy/ui/lua/nvchad/stl/utils.lua:164: attempt to index field 'params' (a nil value)                                 
stack traceback:                                                                                                                                                             
        ...nderg/.local/share/nvim/lazy/ui/lua/nvchad/stl/utils.lua:164: in function <...nderg/.local/share/nvim/lazy/ui/lua/nvchad/stl/utils.lua:163>                       
        [C]: in function 'nvim_exec_autocmds'                                                                                                                                
        /usr/local/share/nvim/runtime/lua/vim/lsp/handlers.lua:53: in function 'handler'                                                                                     
        /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:1013: in function ''                                                                                            
        vim/_editor.lua: in function <vim/_editor.lua:0> 
```

This PR inserts a guard clause at the beginning of the callback in the `autocmds` function in `stl/utils.lua` to check whether `params` exists before proceeding.