### PR TITLE
Fix for possible nil bufwinid during nvdash startup

### DIFF
--- a/lua/nvchad/nvdash/init.lua
+++ b/lua/nvchad/nvdash/init.lua
@@ -28,8 +28,10 @@ M.open = function(buf, win, action)
   win = win or api.nvim_get_current_win()
 
   if not vim.bo.buflisted and action == 'open' then
-    win = vim.fn.bufwinid(vim.t.bufs[1])
-    api.nvim_set_current_win(win)
+    if vim.t.bufs[1] then
+      win = vim.fn.bufwinid(vim.t.bufs[1])
+      api.nvim_set_current_win(win)
+    end
   end
 
   local ns = api.nvim_create_namespace "nvdash"


### PR DESCRIPTION
Fixes #421

This bug can happen if a session is trying to be restored and the file no longer exists.

```
Error executing vim.schedule lua callback: Vim:E5300: Expected a Number or a String
stack traceback:
        [C]: in function 'bufwinid'
        ...gel/.local/share/nvim/lazy/ui/lua/nvchad/nvdash/init.lua:31: in function 'open'
        ...bruno.krugel/.local/share/nvim/lazy/ui/lua/nvchad/au.lua:12: in main chunk
        [C]: in function 'require'
        ...uno.krugel/.local/share/nvim/lazy/ui/lua/nvchad/init.lua:32: in function <...uno.krugel/.local/share/nvim/lazy/ui/lua/nvchad/init.lua:31>
```

![image](https://github.com/user-attachments/assets/bb52d03a-d27b-438f-b808-bdd96763f2b0)
