### PR TITLE
fix: "cursor" in statusline.order does not take into account the apparent position of the characters

### DIFF
--- a/lua/nvchad/stl/default.lua
+++ b/lua/nvchad/stl/default.lua
@@ -51,7 +51,7 @@ M.cwd = function()
   return (vim.o.columns > 85 and ("%#St_cwd_sep#" .. sep_l .. icon .. name)) or ""
 end
 
-M.cursor = "%#St_pos_sep#" .. sep_l .. "%#St_pos_icon# %#St_pos_text# %l/%c "
+M.cursor = "%#St_pos_sep#" .. sep_l .. "%#St_pos_icon# %#St_pos_text# %l/%v "
 M["%="] = "%="
 
 return function()

--- a/lua/nvchad/stl/minimal.lua
+++ b/lua/nvchad/stl/minimal.lua
@@ -61,7 +61,7 @@ M.cwd = function()
 end
 
 M.cursor = function()
-  return gen_block("", "%l/%c", "%#St_Pos_sep#", "%#St_Pos_bg#", "%#St_Pos_txt#")
+  return gen_block("", "%l/%v", "%#St_Pos_sep#", "%#St_Pos_bg#", "%#St_Pos_txt#")
 end
 
 M["%="] = "%="

--- a/lua/nvchad/stl/vscode.lua
+++ b/lua/nvchad/stl/vscode.lua
@@ -23,7 +23,7 @@ M.git = utils.git
 M.lsp_msg = utils.lsp_msg
 M.diagnostics = utils.diagnostics
 M.lsp = utils.lsp
-M.cursor = "%#StText# Ln %l, Col %c  "
+M.cursor = "%#StText# Ln %l, Col %v  "
 M["%="] = "%="
 
 M.cwd = function()

--- a/lua/nvchad/stl/vscode_colored.lua
+++ b/lua/nvchad/stl/vscode_colored.lua
@@ -26,7 +26,7 @@ M.lsp = function()
   return "%#St_Lsp#" .. utils.lsp()
 end
 
-M.cursor = "%#StText# Ln %l, Col %c "
+M.cursor = "%#StText# Ln %l, Col %v "
 M["%="] = "%="
 
 M.cwd = function()


### PR DESCRIPTION
This issue is particularly noticeable when using Tab to align characters and in languages where characters are encoded in two bytes, such as Japanese, Chinese and Korean.
For example, suppose the following strings are displayed in the buffer:
```
Hello
hi	what's up
päivää
こんにちは
你们好
안녕하세요
⭐⭐⭐
🌟🌟🌟
```
In the above, the apparent position of the "好" in "你们好" corresponds to the "o" in "Hello", so 5 would be appropriate, but 7 would appear instead. Similarly, the "i" in "päivää" is also appropriate for 3, but 4 is displayed instead.
Also, the apparent position of the "w" in "what's up" changes in accordance with `tabstop`, but it displays 4 regardless of the setting value.
Furthermore, emojis can have different character code digits, such as "⭐" and "🌟". This means that even if the same number of emojis are written, the values displayed may be different.