### PR TITLE
tabufline is no longer broken when typing `:enew` with the No Name buffer open

### DIFF
--- a/lua/nvchad/tabufline/utils.lua
+++ b/lua/nvchad/tabufline/utils.lua
@@ -50,8 +50,7 @@ M.style_buf = function(nr, i, w)
   local icon_hl = new_hl("DevIconDefault", tbHlName)
 
   local name = filename(buf_name(nr))
-  name = gen_unique_name(name, i) or name
-  name = (name == "" or not name) and " No Name " or name
+  name = (name == "" or not name) and " No Name " or (gen_unique_name(name, i) or name)
 
   if name ~= " No Name " then
     local devicon, devicon_hl = require("nvim-web-devicons").get_icon(name)

--- a/lua/nvchad/tabufline/utils.lua
+++ b/lua/nvchad/tabufline/utils.lua
@@ -50,7 +50,7 @@ M.style_buf = function(nr, i, w)
   local icon_hl = new_hl("DevIconDefault", tbHlName)
 
   local name = filename(buf_name(nr))
-  name = not name and " No Name " or (gen_unique_name(name, i) or name)
+  name = name and (gen_unique_name(name, i) or name) or " No Name "
 
   if name ~= " No Name " then
     local devicon, devicon_hl = require("nvim-web-devicons").get_icon(name)

--- a/lua/nvchad/tabufline/utils.lua
+++ b/lua/nvchad/tabufline/utils.lua
@@ -50,7 +50,7 @@ M.style_buf = function(nr, i, w)
   local icon_hl = new_hl("DevIconDefault", tbHlName)
 
   local name = filename(buf_name(nr))
-  name = (name == "" or not name) and " No Name " or (gen_unique_name(name, i) or name)
+  name = not name and " No Name " or (gen_unique_name(name, i) or name)
 
   if name ~= " No Name " then
     local devicon, devicon_hl = require("nvim-web-devicons").get_icon(name)


### PR DESCRIPTION
fix #442 