### PR TITLE
Don't focus signature_help automatically

### DIFF
--- a/lua/nvchad/lsp/signature.lua
+++ b/lua/nvchad/lsp/signature.lua
@@ -32,7 +32,7 @@ M.setup = function(client, bufnr)
     buffer = bufnr,
     callback = function()
       if check_triggeredChars(triggerChars) then
-        vim.lsp.buf.signature_help()
+        vim.lsp.buf.signature_help { focus = false }
       end
     end,
   })


### PR DESCRIPTION
This plugin calls `vim.lsp.buf.signature_help` to automatically display the signature help while typing.

If `vim.lsp.buf.signature_help` is called while the floating signature help window is already visible, then the floating window will be focused, which will prevent further coding until the focus is changed or the floating window closed.
I don't believe this is the intended behavior.

This PR adds the option `focus = false` to the `vim.lsp.buf.signature_help`, which prevents this call to `signature_help` from focusing the floating window, but still allows it to be focused manually.