### PR TITLE
Update nvdash.load_on_startup behavior:

### DIFF
--- a/lua/nvchad/au.lua
+++ b/lua/nvchad/au.lua
@@ -8,9 +8,6 @@ if config.nvdash.load_on_startup then
   local is_dir = vim.fn.isdirectory(opening_file) == 1
 
   if is_dir or opening_file == "" then
-    if is_dir then
-      vim.cmd.cd(opening_file)
-    end
     local current_buffer = vim.api.nvim_get_current_buf()
     require("nvchad.nvdash").open()
     vim.api.nvim_buf_delete(current_buffer, { force = true, unload = false })

--- a/lua/nvchad/au.lua
+++ b/lua/nvchad/au.lua
@@ -4,12 +4,16 @@ local config = require "nvconfig"
 
 -- load nvdash only on empty file
 if config.nvdash.load_on_startup then
-  local buf_lines = api.nvim_buf_get_lines(0, 0, 1, false)
-  local no_buf_content = api.nvim_buf_line_count(0) == 1 and buf_lines[1] == ""
-  local bufname = api.nvim_buf_get_name(0)
+  local opening_file = vim.fn.expand "%:p"
+  local is_dir = vim.fn.isdirectory(opening_file) == 1
 
-  if bufname == "" and no_buf_content then
+  if is_dir or opening_file == "" then
+    if is_dir then
+      vim.cmd.cd(opening_file)
+    end
+    local current_buffer = vim.api.nvim_get_current_buf()
     require("nvchad.nvdash").open()
+    vim.api.nvim_buf_delete(current_buffer, { force = true, unload = false })
   end
 end
 

--- a/lua/nvchad/au.lua
+++ b/lua/nvchad/au.lua
@@ -1,4 +1,3 @@
-local api = vim.api
 local autocmd = vim.api.nvim_create_autocmd
 local config = require "nvconfig"
 


### PR DESCRIPTION
1. Open not when the buffer is empty, but the file passed is either non-existent or is a directory
2. If it is a directory, cd into it
3. Open nvdash
4. Delete the empty buffer after nvdash is displayed so there is no lingering empty buffer

A few questions:

1. Are you okay with the added behavior from 1 and 2? I feel like this a sane default most people would enjoy but can remove if that's not desired. Or I can add it as an extra option to nvdash if you'd prefer
2. If the added behavior is approved, I can update the documentation so users know of this behavior