### PR TITLE
change(blink): keymap such as cmp

### DIFF
--- a/lua/nvchad/blink/config.lua
+++ b/lua/nvchad/blink/config.lua
@@ -12,8 +12,8 @@ local opts = {
     ["<CR>"] = { "accept", "fallback" },
     ["<C-b>"] = { "scroll_documentation_up", "fallback" },
     ["<C-f>"] = { "scroll_documentation_down", "fallback" },
-    ['<S-Tab>'] = { 'select_prev', 'fallback' },
-    ['<Tab>'] = { 'select_next', 'fallback' },
+    ["<Tab>"] = { "select_next", "snippet_forward", "fallback" },
+    ["<S-Tab>"] = { "select_prev", "snippet_backward", "fallback" },
   },
 
   completion = {

--- a/lua/nvchad/blink/config.lua
+++ b/lua/nvchad/blink/config.lua
@@ -12,6 +12,8 @@ local opts = {
     ["<CR>"] = { "accept", "fallback" },
     ["<C-b>"] = { "scroll_documentation_up", "fallback" },
     ["<C-f>"] = { "scroll_documentation_down", "fallback" },
+    ['<S-Tab>'] = { 'select_prev', 'fallback' },
+    ['<Tab>'] = { 'select_next', 'fallback' },
   },
 
   completion = {


### PR DESCRIPTION
When I use cmp, I got used to using Tab and Shift-Tab to navigate, so I think it would be nice if Blink also had a similar keymap