### PR TITLE
fix(statusline): use non-deprecated get_clients

### DIFF
--- a/lua/nvchad/statusline/default.lua
+++ b/lua/nvchad/statusline/default.lua
@@ -168,7 +168,7 @@ end
 
 M.LSP_status = function()
   if rawget(vim, "lsp") then
-    for _, client in ipairs(vim.lsp.get_active_clients()) do
+    for _, client in ipairs(vim.lsp.get_clients()) do
       if client.attached_buffers[stbufnr()] and client.name ~= "null-ls" then
         return (vim.o.columns > 100 and "%#St_LspStatus#" .. "   LSP ~ " .. client.name .. " ") or "   LSP "
       end


### PR DESCRIPTION
This changes `statusline/default.lua` to use non-deprecated `get_clients()` instead of `get_active_clients()`.
This has been deprecated here and swapping the method calls should not change any behavior:
https://neovim.io/doc/user/deprecated.html#vim.lsp.get_active_clients()