### PR TITLE
Suggestion: Add options for renamer.lua

### DIFF
--- a/doc/nvui.txt
+++ b/doc/nvui.txt
@@ -165,6 +165,16 @@ nvconfig file : |https://github.com/NvChad/ui/blob/v3.0/lua/nvconfig.lua|
        modules = nil,
        bufwidth = 21,
      }, 
+
+     renamer = {
+       border = "single",
+       border_hl_group = "Removed",
+       right_padding = 15,
+       title = "Renamer",
+       title_hl_group = "@comment.danger",
+       mode = "insert",
+       show_original = true,
+     },
    },
 
    nvdash = {
@@ -643,9 +653,21 @@ It's preferred to put the dofile code in your plugin's config func
 ------------------------------------------------------------------------------
 7.2 Renamer                                                   *nvui.lsp.renamer*
 
-This is a function will will rename variable under cursor
+This function renames the variable under the cursor.
 >lua
  require "nvchad.lsp.renamer"()
+
+UI can be customized by changing options in your chadrc
+>lua
+  renamer = {
+    border = "single", -- single/double/bold/rounded/solid/string[]
+    border_hl_group = "Removed",
+    right_padding = 15,
+    title = "Renamer",
+    title_hl_group = "@comment.danger",
+    mode = "insert", -- insert/normal
+    show_original = true, -- set to false if you don't want to autofill
+  },
 
 ==============================================================================
 8. Colorify			                                 *nvui.colorify*

--- a/doc/nvui.txt
+++ b/doc/nvui.txt
@@ -656,8 +656,8 @@ are listed in the example.
    right_padding = 15,
    title = "Renamer",
    title_hl_group = "@comment.danger",
-   mode = "insert", -- insert/normal
    show_original = true, -- set to false if you don't want to autofill
+   allow_normal = false, -- set to true to access normal in renamer prompt
  })
 
 ==============================================================================

--- a/doc/nvui.txt
+++ b/doc/nvui.txt
@@ -165,16 +165,6 @@ nvconfig file : |https://github.com/NvChad/ui/blob/v3.0/lua/nvconfig.lua|
        modules = nil,
        bufwidth = 21,
      }, 
-
-     renamer = {
-       border = "single",
-       border_hl_group = "Removed",
-       right_padding = 15,
-       title = "Renamer",
-       title_hl_group = "@comment.danger",
-       mode = "insert",
-       show_original = true,
-     },
    },
 
    nvdash = {
@@ -657,17 +647,18 @@ This function renames the variable under the cursor.
 >lua
  require "nvchad.lsp.renamer"()
 
-UI can be customized by changing options in your chadrc
+UI can be customized by passing a table of options to this function. Defaults
+are listed in the example.
 >lua
-  renamer = {
-    border = "single", -- single/double/bold/rounded/solid/string[]
-    border_hl_group = "Removed",
-    right_padding = 15,
-    title = "Renamer",
-    title_hl_group = "@comment.danger",
-    mode = "insert", -- insert/normal
-    show_original = true, -- set to false if you don't want to autofill
-  },
+ require "nvchad.lsp.renamer"({
+   border = "single", -- see :h winborder for additional options
+   border_hl_group = "Removed",
+   right_padding = 15,
+   title = "Renamer",
+   title_hl_group = "@comment.danger",
+   mode = "insert", -- insert/normal
+   show_original = true, -- set to false if you don't want to autofill
+ })
 
 ==============================================================================
 8. Colorify			                                 *nvui.colorify*

--- a/lua/nvchad/lsp/renamer.lua
+++ b/lua/nvchad/lsp/renamer.lua
@@ -1,6 +1,5 @@
 local lsp = vim.lsp
 local api = vim.api
-local opts = require("nvconfig").ui.renamer
 
 local function get_text_at_range(range, position_encoding)
   return api.nvim_buf_get_text(
@@ -54,9 +53,20 @@ local function get_symbol_to_rename(cb)
   end
 end
 
-return function()
+return function(opts)
   get_symbol_to_rename(function(to_rename)
     local buf = api.nvim_create_buf(false, true)
+
+    local default_opts = {
+      border = "single",
+      right_padding = 15,
+      title = "Rename",
+      title_hl_group = "@comment.danger",
+      border_hl_group = "Removed",
+      show_original = "true",
+      mode = "insert",
+    }
+    opts = vim.tbl_deep_extend('force', default_opts, opts or {})
 
     local winopts = {
       height = 1,

--- a/lua/nvchad/lsp/renamer.lua
+++ b/lua/nvchad/lsp/renamer.lua
@@ -63,8 +63,8 @@ return function(opts)
       title = "Rename",
       title_hl_group = "@comment.danger",
       border_hl_group = "Removed",
-      show_original = "true",
-      mode = "insert",
+      show_original = true,
+      allow_normal = false,
     }
     opts = vim.tbl_deep_extend('force', default_opts, opts or {})
 
@@ -92,17 +92,16 @@ return function(opts)
 
     vim.bo[buf].buftype = "prompt"
     vim.fn.prompt_setprompt(buf, "")
-    if opts.mode == "insert" then
-      vim.api.nvim_input "A"
-    else
-      vim.api.nvim_input "$"
-    end
 
-    local exitMapModes = { "n" }
-    if opts.mode == "insert" then
-      exitMapModes = { "i", "n" }
+    vim.api.nvim_input "A"
+
+    local modes
+    if opts.allow_normal then
+      modes = { "n" }
+    else
+      modes = { "n", "i" }
     end
-    vim.keymap.set(exitMapModes, "<Esc>", function()
+    vim.keymap.set(modes, "<Esc>", function()
       api.nvim_buf_delete(buf, { force = true })
     end, { buffer = buf })
 

--- a/lua/nvchad/lsp/renamer.lua
+++ b/lua/nvchad/lsp/renamer.lua
@@ -1,5 +1,6 @@
 local lsp = vim.lsp
 local api = vim.api
+local opts = require("nvconfig").ui.renamer
 
 local function get_text_at_range(range, position_encoding)
   return api.nvim_buf_get_text(
@@ -60,26 +61,38 @@ return function()
     local winopts = {
       height = 1,
       style = "minimal",
-      border = "single",
+      border = opts.border,
       row = 1,
       col = 1,
       relative = "cursor",
-      width = #to_rename + 15,
-      title = { { " Renamer ", "@comment.danger" } },
+      width = #to_rename + opts.right_padding,
+      title = { { " " .. opts.title .. " ", opts.title_hl_group } },
       title_pos = "center",
     }
 
     local win = api.nvim_open_win(buf, true, winopts)
-    vim.wo[win].winhl = "Normal:Normal,FloatBorder:Removed"
+    vim.wo[win].winhl = "Normal:Normal,FloatBorder:" .. opts.border_hl_group
     api.nvim_set_current_win(win)
 
-    api.nvim_buf_set_lines(buf, 0, -1, true, { " " .. to_rename })
+    if opts.show_original then
+      api.nvim_buf_set_lines(buf, 0, -1, true, { " " .. to_rename })
+    else
+      api.nvim_buf_set_lines(buf, 0, -1, true, { " " })
+    end
 
     vim.bo[buf].buftype = "prompt"
     vim.fn.prompt_setprompt(buf, "")
-    vim.api.nvim_input "A"
+    if opts.mode == "insert" then
+      vim.api.nvim_input "A"
+    else
+      vim.api.nvim_input "$"
+    end
 
-    vim.keymap.set({ "i", "n" }, "<Esc>", function()
+    local exitMapModes = { "n" }
+    if opts.mode == "insert" then
+      exitMapModes = { "i", "n" }
+    end
+    vim.keymap.set(exitMapModes, "<Esc>", function()
       api.nvim_buf_delete(buf, { force = true })
     end, { buffer = buf })
 

--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -39,16 +39,6 @@ local options = {
       modules = nil,
       bufwidth = 21,
     },
-
-    renamer = {
-      border = "single",
-      border_hl_group = "Removed",
-      right_padding = 15,
-      title = "Renamer",
-      title_hl_group = "@comment.danger",
-      mode = "insert",
-      show_original = true,
-    },
   },
 
   nvdash = {

--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -39,6 +39,16 @@ local options = {
       modules = nil,
       bufwidth = 21,
     },
+
+    renamer = {
+      border = "single",
+      border_hl_group = "Removed",
+      right_padding = 15,
+      title = "Renamer",
+      title_hl_group = "@comment.danger",
+      mode = "insert",
+      show_original = true,
+    },
   },
 
   nvdash = {

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -55,6 +55,7 @@
 ---@field telescope? NvTelescopeConfig
 ---@field statusline? NvStatusLineConfig
 ---@field tabufline? NvTabLineConfig
+---@field renamer? NvRenamerConfig
 --- Whether to enable LSP Semantic Tokens highlighting
 --- List of extras themes for other plugins not in NvChad that you want to compile
 
@@ -116,6 +117,22 @@
 ---     }
 --- ```
 ---@field modules? table<string, fun(): string>
+
+---@class NvRenamerConfig
+--- See h:api-win_config and h:winborder
+---@field border? ("single"|"double"|"bold"|"rounded"|"solid") | string[]
+--- Link the highlight group of the border characters
+---@field border_hl_group? string
+--- Width is calculated as the length of the symbol + this many chars
+---@field right_padding? number
+--- Text displayed atop window
+---@field title? string
+--- Link the highlight group of the title text
+---@field title_hl_group? string
+--- Optionally select a mode in the buffer after entering
+---@field mode? ("normal"|"insert")
+--- If false, do not copy the symbol name into the buffer
+---@field show_original boolean
 
 ---@class NvDashConfig
 --- Whether to open dashboard on opening nvim


### PR DESCRIPTION
Add UI customization for the Renamer buffer, including:
- border style and color
- title text and color
- padding

Also be able to:
- Enter/Use the buffer in normal mode (previously was always insert and <esc> was mapped to cancelling the operation)
- Exclude the original variable name (saves keystrokes)

The default config is just what originally existed beforehand.

P.S. this is my first ever OSS PR, so please excuse if there is any faux pas 🙏 