### PR TITLE
fix(mason): add vue_ls

### DIFF
--- a/lua/nvchad/mason/names.lua
+++ b/lua/nvchad/mason/names.lua
@@ -205,6 +205,7 @@ return {
   visualforce_ls = "visualforce-language-server",
   vls = "vls",
   volar = "vue-language-server",
+  vue_ls = "vue-language-server",
   vtsls = "vtsls",
   vuels = "vetur-vls",
   wgsl_analyzer = "wgsl-analyzer",


### PR DESCRIPTION
'volar' renamed to 'vue_ls' based on: https://github.com/neovim/nvim-lspconfig/commit/221bc7bd182c78453c67db34e4bc465dc13612d4
If we set volar instead of vue_ls, the warning will show
![image](https://github.com/user-attachments/assets/39c56b43-d765-4b60-a0f9-9f58203cd4f9)
