### PR TITLE
fix: backward compatibility with theme defined in ui

### DIFF
--- a/lua/nvchad/themes/mappings.lua
+++ b/lua/nvchad/themes/mappings.lua
@@ -20,7 +20,8 @@ map({ "i", "n" }, { "<cr>" }, function()
   state.confirmed = true
   local name = state.themes_shown[state.index]
   package.loaded.chadrc = nil
-  local old_theme = require("chadrc").base46.theme
+  local chadrc = require("chadrc")
+  local old_theme = (chadrc.ui and chadrc.ui.theme) or chadrc.base46.theme
 
   old_theme = '"' .. old_theme .. '"'
   require("nvchad.utils").replace_word(old_theme, '"' .. name .. '"')


### PR DESCRIPTION
As an old user, who had the theme defined in `M.ui` instead of `M.base46` (following the [change](https://github.com/NvChad/NvChad/issues/2938)), I ran into an error very similar to the one described [here](https://github.com/NvChad/base46/issues/325), each time I changed the theme.
The error pointed to be triggered at [this](https://github.com/NvChad/ui/blob/80b577c0acdd458b60db62ba2a84625abb638bbb/lua/nvchad/themes/mappings.lua#L23) particular line of code:

https://github.com/NvChad/ui/blob/80b577c0acdd458b60db62ba2a84625abb638bbb/lua/nvchad/themes/mappings.lua#L23

Following the above mentioned [issue](https://github.com/NvChad/base46/issues/325), and the associated [commit](https://github.com/NvChad/base46/commit/4f4a9d205ccef5785ca1d0ad875752478b8ef2a4), I thought it would be good to have backward compatibility here too.