### PR TITLE
nvdash: clamp cursor row/column to prevent out-of-range errors

### DIFF
--- a/lua/nvchad/nvdash/init.lua
+++ b/lua/nvchad/nvdash/init.lua
@@ -210,10 +210,20 @@ M.open = function(buf, win, action)
         if cmd and x.cmd then
           vim.cmd(x.cmd)
         else
-          return { x.i, x.col }
+          local line = api.nvim_buf_get_lines(buf, x.i - 1, x.i, false)[1] or ""
+          local col = math.max(0, math.min(x.col, #line))
+          return { x.i, col }
         end
       end
     end
+
+    if key_lines[1] then
+      local line = api.nvim_buf_get_lines(buf, key_lines[1].i - 1, key_lines[1].i, false)[1] or ""
+      local col = math.max(0, math.min(key_lines[1].col, #line))
+      return { key_lines[1].i, col }
+    end
+
+    return { 1, 0 }
   end
 
   map({ "k", "<up>" }, function()

--- a/lua/nvchad/nvdash/init.lua
+++ b/lua/nvchad/nvdash/init.lua
@@ -188,7 +188,17 @@ M.open = function(buf, win, action)
   vim.wo[win].virtualedit = "all"
 
   if key_lines[1] then
-    api.nvim_win_set_cursor(win, { key_lines[1].i, key_lines[1].col })
+    local row = key_lines[1].i
+    local col = key_lines[1].col
+
+    local line = api.nvim_buf_get_lines(buf, row - 1, row, false)[1] or ""
+    if col > #line then
+      col = #line
+    elseif col < 0 then
+      col = 0
+    end
+
+    api.nvim_win_set_cursor(win, { row, col })
   end
 
   local key_movements = function(n, cmd)


### PR DESCRIPTION
I received some out-of-range Lua errors when loading NvDash (in my essentially stock NvChad set-up), due to large text-art being rendered on a small terminal window.

The error:

```
Error executing vim.schedule lua callback: ...han/.local/share/nvim/lazy/ui/lua/nvchad/nvdash/init.l
ua:191: Column value outside range
stack traceback:
        [C]: in function 'nvim_win_set_cursor'
        ...han/.local/share/nvim/lazy/ui/lua/nvchad/nvdash/init.lua:191: in function 'open'
        ...rs/zachmahan/.local/share/nvim/lazy/ui/lua/nvchad/au.lua:12: in main chunk
        [C]: in function 'require'
        .../zachmahan/.local/share/nvim/lazy/ui/lua/nvchad/init.lua:32: in function <.../zachmahan/.
local/share/nvim/lazy/ui/lua/nvchad/init.lua:31
```

My fixes:

- Clamp the cursor column to the length of the line.
- Ensure key_movements always returns a valid {row, col} tuple.

These changes prevent E5108 errors when opening or scrolling in NvDash in small terminal windows with large text-art.