### PR TITLE
fix(colorify): clamp RGBA values to prevent invalid hex strings (reopened PR #500)

### DIFF
--- a/lua/nvchad/colorify/methods.lua
+++ b/lua/nvchad/colorify/methods.lua
@@ -7,6 +7,14 @@ local needs_hl = utils.not_colored
 
 local M = {}
 
+local function to_hex(r, g, b, a)
+  local clamp = function(x)
+    x = math.floor((x or 0) * (a or 1) * 255 + 0.5)
+    return math.max(0, math.min(x, 255))
+  end
+  return string.format("#%02x%02x%02x", clamp(r), clamp(g), clamp(b))
+end
+
 M.hex = function(buf, line, str)
   for col, hex in str:gmatch "()(#%x%x%x%x%x%x)" do
     col = col - 1
@@ -53,7 +61,7 @@ M.lsp_var = function(buf, line, min, max)
             a = a / 255
           end
 
-          local hex = string.format("#%02x%02x%02x", r * a * 255, g * a * 255, b * a * 255)
+					local hex = to_hex(r, g, b, a)
 
           local hl_group = utils.add_hl(hex)
 


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in `nvchad.colorify.methods.lua` where colors received from **LSP via `textDocument/documentColor` were incorrectly converted from RGBA to hex strings**. 

The original implementation directly multiplied floating-point values without clamping or rounding, producing invalid hex strings such as `#fe01fe01fe01`, which caused runtime crashes when passed to `nvim_set_hl()` (see colorify/utils.lua: line #31).

## What was changed
- Introduced a safe `to_hex(r, g, b, a)` function that:
  - Multiplies RGBA values with proper rounding (`+0.5`)
  - Clamps each component to the 0–255 range
  - Constructs valid 7-character hex strings of the form `#rrggbb`

- Replaced the direct `string.format(...)` call with this safe method inside the LSP color handler.

## Why this matters
Without this fix, certain LSP servers (e.g. CSS, SCSS, Tailwind) may cause hard crashes when they return slightly invalid or unnormalized RGBA values. This bug is reproducible with color-aware LSPs (e.g. for CSS, SCSS, TailwindCSS, or Vue via Volar) that return fractional RGBA values.

## Example Error
Error executing vim.schedule lua callback: 
.../colorify/utils.lua:31:
Invalid highlight color: '#fe01fe01fe01'

## Additional Notes
No visual or functional changes for users.