### PR TITLE
fix(tabufline): prevent invalid buffer ID error on BufAdd event

### DIFF
--- a/lua/nvchad/tabufline/lazyload.lua
+++ b/lua/nvchad/tabufline/lazyload.lua
@@ -33,8 +33,10 @@ autocmd({ "BufAdd", "BufEnter", "tabnew" }, {
 
     -- remove unnamed buffer which isnt current buf & modified
     if args.event == "BufAdd" then
-      if #api.nvim_buf_get_name(bufs[1]) == 0 and not get_opt("modified", { buf = bufs[1] }) then
-        table.remove(bufs, 1)
+      if #bufs > 0 and api.nvim_buf_is_valid(bufs[1]) then
+        if #api.nvim_buf_get_name(bufs[1]) == 0 and not get_opt("modified", { buf = bufs[1] }) then
+          table.remove(bufs, 1)
+        end
       end
     end
 


### PR DESCRIPTION
## Fix: Invalid buffer ID error in tabufline lazyload

### Problem

`nvim_buf_get_name()` crashes with "Invalid buffer id" when using preview features in Neo-tree, FZF-lua, or Telescope.

**Error:**

```vim
Error executing lua callback: .../nvchad/tabufline/lazyload.lua:36: Invalid buffer id: 1
```

**Reproduction:**
1. Open Neo-tree preview (Tab key)
2. Open the file
3. Error occurs

### Cause

Line 36 accesses `bufs[1]` without validating:
- Table has elements (`#bufs > 0`)
- Buffer is valid (`nvim_buf_is_valid()`)

Preview buffers can cause `bufs` to be empty or contain invalid buffer IDs.

### Solution

Add validation before accessing `bufs[1]`:

```lua
if args.event == "BufAdd" then
  if #bufs > 0 and api.nvim_buf_is_valid(bufs[1]) then
    if #api.nvim_buf_get_name(bufs[1]) == 0 and not get_opt("modified", { buf = bufs[1] }) then
      table.remove(bufs, 1)
    end
  end
end
```
