### PR TITLE
Fix boundary case behavior for buffer movement (Circular rotation)

### DIFF
--- a/lua/nvchad/tabufline/init.lua
+++ b/lua/nvchad/tabufline/init.lua
@@ -107,8 +107,12 @@ M.move_buf = function(n)
 
   for i, bufnr in ipairs(bufs) do
     if bufnr == cur_buf() then
-      if n < 0 and i == 1 or n > 0 and i == #bufs then
-        bufs[1], bufs[#bufs] = bufs[#bufs], bufs[1]
+      if n < 0 and i == 1 then
+        table.insert(bufs, bufs[i])
+        table.remove(bufs, i)
+      elseif n > 0 and i == #bufs then
+        table.insert(bufs, 1, bufs[i])
+        table.remove(bufs, i + 1)
       else
         bufs[i], bufs[i + n] = bufs[i + n], bufs[i]
       end


### PR DESCRIPTION
Hello! I often use your plugin, and the current boundary case behavior is a bit annoying. When moving the first buffer to the left or the last buffer to the right, we shouldn't just swap their places. Instead, we should move the first element to the very end (or vice versa) without swapping it with the neighbor.

Current behavior (Simple Swap):
State 1: <img width="1345" height="173" alt="image" src="https://github.com/user-attachments/assets/d402178f-65cd-49c7-864f-2c71906e1982" />
State 2: <img width="1345" height="173" alt="image" src="https://github.com/user-attachments/assets/790bd8ec-ded6-44cd-98ec-6f5df16d1762" />
1. I move from (State 1) first tab to the left
2. We have state (State 2) where last and first swap places
3. Move from (State 2) to the right, produce (State 1)...

New behavior (Circular Rotation):
State 1: <img width="1345" height="173" alt="image" src="https://github.com/user-attachments/assets/bf310e8a-7518-4bff-ba93-8859dba336d5" />
State 2: 
<img width="1345" height="173" alt="image" src="https://github.com/user-attachments/assets/61f6baeb-1cb4-4bec-8570-84f3e2d9b5aa" />

Attention on the second and pre-last elements the entire list shifts to maintain order.