### PR TITLE
Removed two default keymaps from blink.cmp

### DIFF
--- a/lua/nvchad/blink/config.lua
+++ b/lua/nvchad/blink/config.lua
@@ -10,8 +10,6 @@ local opts = {
   keymap = {
     preset = "default",
     ["<CR>"] = { "accept", "fallback" },
-    ["<C-b>"] = { "scroll_documentation_up", "fallback" },
-    ["<C-f>"] = { "scroll_documentation_down", "fallback" },
     ["<Tab>"] = { "select_next", "snippet_forward", "fallback" },
     ["<S-Tab>"] = { "select_prev", "snippet_backward", "fallback" },
   },


### PR DESCRIPTION
The "default" keymap presets already include these two keymaps with same actions. 

`['<C-b>'] = { 'scroll_documentation_up', 'fallback' }`

and 

`['<C-f>'] = { 'scroll_documentation_down', 'fallback' },`

Thank you :) 