### PR TITLE
Fixing blink tab in insert mode

### DIFF
--- a/lua/nvchad/blink/config.lua
+++ b/lua/nvchad/blink/config.lua
@@ -1,5 +1,6 @@
 dofile(vim.g.base46_cache .. "blink")
 
+local key = vim.api.nvim_replace_termcodes("<Tab>", true, false, true)
 local opts = {
   snippets = { preset = "luasnip" },
   cmdline = { enabled = true },
@@ -10,7 +11,9 @@ local opts = {
   keymap = {
     preset = "default",
     ["<CR>"] = { "accept", "fallback" },
-    ["<Tab>"] = { "select_next", "snippet_forward", "fallback" },
+    ["<Tab>"] = { "select_next", "snippet_forward", function()
+      vim.api.nvim_feedkeys(key, "n", false)
+    end },
     ["<S-Tab>"] = { "select_prev", "snippet_backward", "fallback" },
   },
 


### PR DESCRIPTION
You might have noticed, after enabling blink, `<Tab>` don't insert space anymore. Instead cursor goes to the beginning of the line.  
This happens because the "fallback" of blink.cmp is not able to fetch insert space function.  
Now till blink.cmp fixes it, I think this is a good enough fix.