### PR TITLE
fix(lsp.renamer): fix renamer buffer got cleared when open

### DIFF
--- a/lua/nvchad/lsp/renamer.lua
+++ b/lua/nvchad/lsp/renamer.lua
@@ -73,10 +73,9 @@ return function()
     vim.wo[win].winhl = "Normal:Normal,FloatBorder:Removed"
     api.nvim_set_current_win(win)
 
-    api.nvim_buf_set_lines(buf, 0, -1, true, { " " .. to_rename })
-
     vim.bo[buf].buftype = "prompt"
     vim.fn.prompt_setprompt(buf, "")
+    api.nvim_buf_set_lines(buf, 0, -1, true, { " " .. to_rename })
     vim.api.nvim_input "A"
 
     vim.keymap.set({ "i", "n" }, "<Esc>", function()


### PR DESCRIPTION
In neovim 0.12+ the renamer buffer won't display the default `to_rename` text. This might be caused by `prompt_setprompt()` method that always ensures a clear buffer when configuring a new prompt. The issue is fixed by calling `nvim_buf_set_lines()` after the prompt is properly setup.

## Before the fix:
<img width="687" height="321" alt="image" src="https://github.com/user-attachments/assets/aa9fa74c-824a-45d2-be8d-a198a4468309" />

## After:
<img width="745" height="320" alt="image" src="https://github.com/user-attachments/assets/06c8e833-cd19-431e-a422-7ff81633788f" />
