### PR TITLE
fix(lsp.renamer): ensure falling back to normal mode after renaming

### DIFF
--- a/lua/nvchad/lsp/renamer.lua
+++ b/lua/nvchad/lsp/renamer.lua
@@ -83,6 +83,15 @@ return function()
       api.nvim_buf_delete(buf, { force = true })
     end, { buffer = buf })
 
+    api.nvim_create_autocmd("BufLeave", {
+      buffer = buf,
+      callback = function()
+        vim.schedule(function()
+          vim.cmd "stopinsert"
+        end)
+      end,
+    })
+
     vim.fn.prompt_setcallback(buf, function(text)
       local newName = vim.trim(text)
       api.nvim_buf_delete(buf, { force = true })


### PR DESCRIPTION
After renaming, my expected behavior is to enter normal mode again. But if do some changes in normal mode and then hit enter. My neovim will be in insert mode instead. Here is the video before the fix:

https://github.com/user-attachments/assets/955cf121-6083-4d38-9ec2-c01371e4fc3a

After the fix:

https://github.com/user-attachments/assets/a90f9af8-9534-4a41-85bd-67bb9d069fc1

