### PR TITLE
fix(tabufline): implement show_numbers option to display buffer index

### DIFF
--- a/lua/nvchad/tabufline/utils.lua
+++ b/lua/nvchad/tabufline/utils.lua
@@ -68,8 +68,8 @@ M.style_buf = function(nr, i, w)
   name = string.sub(name, 1, maxname_len - 2) .. (#name > maxname_len and ".." or "")
   name = M.txt(name, tbHlName)
 
-  name = strep(" ", pad - 1) .. (icon_hl .. icon .. name) .. strep(" ", pad - 1)
-
+  local num = opts.show_numbers and (M.txt(i .. " ", tbHlName)) or ""
+  name = strep(" ", pad - 1) .. (num .. icon_hl .. icon .. name) .. strep(" ", pad - 1)
   local close_btn = btn(" 󰅖 ", nil, "KillBuf", nr)
   name = btn(name, nil, "GoToBuf", nr)
 


### PR DESCRIPTION
## Problem

The `show_numbers` option is documented in `nvchad_types/chadrc.lua` and appears 
in the tabufline config, but was never implemented. When set to `true`, no numbers 
are displayed on the buffer tabs.

Additionally, the number shown was the internal Neovim `bufnr` (e.g. 6, 12, 24) 
instead of the sequential buffer index (1, 2, 3...).

## Solution

In `style_buf(nr, i, w)`, the parameter `i` already receives the correct sequential 
index from `modules.lua`, but was never used. This fix reads `opts.show_numbers` and 
prepends the index `i` to the buffer tab label when enabled.

## Changes

- `lua/nvchad/tabufline/utils.lua`: use parameter `i` to display buffer index when 
  `show_numbers = true`