### PR TITLE
types and docs for integrations_dir

### DIFF
--- a/doc/nvui.txt
+++ b/doc/nvui.txt
@@ -623,6 +623,16 @@ It's preferred to put the dofile code in your plugin's config func
     end
  }
 <
+To include custom integrations, use the `base46.integrations_dir` option to
+define a module name that contains the custom integration files. Loading
+from the custom module location will only be tried if there is no matching
+official integration.
+>lua
+ M.base46 = {
+   integrations_dir = "foo.integrations",
+   integrations = { "dap", "hop", "customname" },
+ }
+<
 ------------------------------------------------------------------------------
 6.5 Local themes		                      *nvui.base46.local_themes*
 

--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -4,6 +4,7 @@ local options = {
     theme = "onedark", -- default theme
     hl_add = {},
     hl_override = {},
+    integrations_dir = nil,
     integrations = {},
     changed_themes = {},
     transparency = false,

--- a/nvchad_types/all_hl_groups.lua
+++ b/nvchad_types/all_hl_groups.lua
@@ -1661,3 +1661,4 @@ error("Requiring a meta file")
 ---| "'trouble'"
 ---| "'vim-illuminate'"
 ---| "'whichkey'"
+---| string

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -46,6 +46,8 @@
 --- You can try out the theme by executing `:Telescope themes`
 --- see https://github.com/NvChad/base46/tree/master/lua/base46/themes
 ---@field theme? ThemeName
+--- module name for loading custom integrations
+---@field integrations_dir? string
 ---@field integrations? Base46Integrations[]
 
 --- UI related configuration

--- a/scripts/update-nvchad-types.lua
+++ b/scripts/update-nvchad-types.lua
@@ -87,6 +87,9 @@ local gen_highlights = function()
       end
     end
   end
+  -- allow string type to keep completion through enum values
+  -- while avoiding linter warnings for custom integrations.
+  table.insert(contents, string.format "---| string")
 
   for name, integration in vim.spairs(hlgroups) do
     if string.sub(name, 1, 1) == "@" then


### PR DESCRIPTION
Fix integrations type to account for integrations_dir functionality and extend docs explaining the new feature.

When using custom integrations loaded from the new integrations_dir
opt, it produces type/linter errors, as the used custom integrations are
not part of the enum values. Allow strings as well for the type, which
is the sweat spot by allowing for type based completions when defining
the upstream integrations, but also allow custom integrations without
linter type errors.