### PR TITLE
fix(signature): guard against invalid buffer on setup

### DIFF
--- a/lua/nvchad/lsp/signature.lua
+++ b/lua/nvchad/lsp/signature.lua
@@ -15,6 +15,11 @@ local function check_triggeredChars(triggerChars)
 end
 
 M.setup = function(client, bufnr)
+  -- Guard against invalid or already deleted buffers (e.g. async vim.schedule callbacks)
+  if not bufnr or not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
   local group = api.nvim_create_augroup("LspSignature", { clear = false })
   api.nvim_clear_autocmds { group = group, buffer = bufnr }
 


### PR DESCRIPTION
Prevent `Invalid buffer id` error when `M.setup` is executed on an already closed/deleted buffer (e.g. from async callbacks).