### PR TITLE
Default options in nvconfig for theme picker. 

### DIFF
--- a/doc/nvui.txt
+++ b/doc/nvui.txt
@@ -132,6 +132,7 @@ nvconfig file : |https://github.com/NvChad/ui/blob/v3.0/lua/nvconfig.lua|
      theme = "onedark",
      hl_add = {},
      hl_override = {},
+     integrations_dir = nil,
      integrations = {},
      changed_themes = {},
      transparency = false,
@@ -224,6 +225,13 @@ nvconfig file : |https://github.com/NvChad/ui/blob/v3.0/lua/nvconfig.lua|
      virt_text = "󱓻 ",
      highlight = { hex = true, lspvars = true },
    },
+
+   themepicker = {
+     style = "bordered", -- bordered, flat, compact
+     border = false,
+     icon = nil, -- set it to nil to use default icons preferred by the style
+  },
+
  }
  
 ==============================================================================
@@ -757,20 +765,21 @@ NOTE: API
 - This is a theme picker created from volt ui library! 
 - It has 3 styles, `compact`, `minimal` & `default`
 
+These are the default options for Theme picker 
+>lua
+ M.themepicker = {
+    style = "bordered", -- bordered, flat, compact
+    border = false,
+    icon = nil, -- set it to nil to use default icons preferred by the style
+ },
+<
+
 NOTE: API
 >lua
  require("nvchad.themes").open()
 
- opts: ~  
-
-  {
-    icon = "", -- optional
-    style = "compact", -- optional! compact/flat/bordered
-    border = false,
-  }
-
  example: ~
 
-   require("nvchad.themes").open { style = "flat" }
+ require("nvchad.themes").open { style = "flat" }
 <
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/nvchad/themes/init.lua
+++ b/lua/nvchad/themes/init.lua
@@ -4,7 +4,6 @@ local volt = require "volt"
 local ui = require "nvchad.themes.ui"
 local state = require "nvchad.themes.state"
 local colors = dofile(vim.g.base46_cache .. "colors")
-local opts = require("nvconfig").themepicker
 
 state.ns = api.nvim_create_namespace "NvThemes"
 
@@ -27,11 +26,12 @@ local gen_word_pad = function()
   state.longest_name = largest
 end
 
-M.open = function()
+M.open = function(opts)
+  opts = opts or require("nvconfig").themepicker
   state.buf = api.nvim_create_buf(false, true)
   state.input_buf = api.nvim_create_buf(false, true)
 
-  state.style = opts.style
+  state.style = opts.style or "bordered"
 
   local style = state.style
 

--- a/lua/nvchad/themes/init.lua
+++ b/lua/nvchad/themes/init.lua
@@ -4,6 +4,7 @@ local volt = require "volt"
 local ui = require "nvchad.themes.ui"
 local state = require "nvchad.themes.state"
 local colors = dofile(vim.g.base46_cache .. "colors")
+local opts = require("nvconfig").themepicker
 
 state.ns = api.nvim_create_namespace "NvThemes"
 
@@ -26,12 +27,11 @@ local gen_word_pad = function()
   state.longest_name = largest
 end
 
-M.open = function(opts)
-  opts = opts or {}
+M.open = function()
   state.buf = api.nvim_create_buf(false, true)
   state.input_buf = api.nvim_create_buf(false, true)
 
-  state.style = opts.style or "bordered"
+  state.style = opts.style
 
   local style = state.style
 

--- a/lua/nvconfig.lua
+++ b/lua/nvconfig.lua
@@ -114,6 +114,12 @@ local options = {
     virt_text = "󱓻 ",
     highlight = { hex = true, lspvars = true },
   },
+
+  themepicker = {
+    style = "bordered", -- bordered, flat, compact
+    border = false,
+    icon = nil, -- set it to nil to use default icons preferred by the style
+  },
 }
 
 local status, chadrc = pcall(require, "chadrc")

--- a/nvchad_types/chadrc.lua
+++ b/nvchad_types/chadrc.lua
@@ -9,6 +9,7 @@
 ---@field mason? MasonConfig
 ---@field colorify? ColorifyConfig
 ---@field nvdash? NvDashConfig
+---@field themepicker? ThemePickerConfig
 
 ---@class Base46Config
 --- List of highlights group to add.
@@ -180,3 +181,8 @@
 ---@class NvCmpFormatColors
 ---@field icon? string # icon to use for color swatches
 ---@field lsp? boolean # show colors from tailwind/css/astro lsp in menu
+
+---@class ThemePickerConfig
+---@field style? "bordered"|"flat"|"compact"
+---@field border? boolean
+---@field icon? string


### PR DESCRIPTION
In this PR, we can customize the theme picker from `chadrc.lua`, instead of re-mapping the "th" keybinding and passing the options inside of it even though the api implementation is still there, 

The current logic looks like, if we did not provide any options while calling the `open()` func, it'll take it from the nvconfig, instead of default hardcoded values.

Updated config looks like: 
```lua
 M.themepicker = {
    style = "bordered", -- bordered, flat, compact
    border = false,
    icon = nil, -- set it to nil to use default icons preferred by the style
  },
```

No breaking changes were involved, also added the types and docs for the updated implementation. 